### PR TITLE
Tell HttpClient Response to not throw exception

### DIFF
--- a/src/Service/Webhook/WebhookExecutionService.php
+++ b/src/Service/Webhook/WebhookExecutionService.php
@@ -72,7 +72,7 @@ class WebhookExecutionService implements LoggerAwareInterface
         $response = $client->request('POST', (string)$webhook->getUrl(), $options);
 
         $activity->setStatusCode($response->getStatusCode());
-        $activity->setResponseHeaders($response->getHeaders());
-        $activity->setResponse($response->getContent());
+        $activity->setResponseHeaders($response->getHeaders(false));
+        $activity->setResponse($response->getContent(false));
     }
 }

--- a/tests/Unit/Service/Webhook/WebhookExecutionServiceTest.php
+++ b/tests/Unit/Service/Webhook/WebhookExecutionServiceTest.php
@@ -50,8 +50,8 @@ class WebhookExecutionServiceTest extends AbstractTestCase
 
         $response = $this->createMock(ResponseInterface::class);
         $response->method('getStatusCode')->willReturn(200);
-        $response->method('getHeaders')->willReturn(['response' => 'headers']);
-        $response->method('getContent')->willReturn('content');
+        $response->method('getHeaders')->with(false)->willReturn(['response' => 'headers']);
+        $response->method('getContent')->with(false)->willReturn('content');
 
         $this->activityRepository->expects(self::once())->method('save')->with(self::isInstanceOf(WebhookActivity::class), true);
         $this->httpClient->expects(self::once())


### PR DESCRIPTION
To be able to log the webhook activity, getHeaders and getContent from Response shouldn't throw exception, but just return the data.