### PR TITLE
Only invoke git fetch when necessary

### DIFF
--- a/src/Service/Git/CacheableGitRepositoryService.php
+++ b/src/Service/Git/CacheableGitRepositoryService.php
@@ -14,10 +14,10 @@ class CacheableGitRepositoryService extends GitRepositoryService
     /**
      * @throws RepositoryException
      */
-    public function getRepository(string $repositoryUrl): GitRepository
+    public function getRepository(string $repositoryUrl, bool $fetch = false): GitRepository
     {
         if (isset($this->repositories[$repositoryUrl]) === false) {
-            $this->repositories[$repositoryUrl] = parent::getRepository($repositoryUrl);
+            $this->repositories[$repositoryUrl] = parent::getRepository($repositoryUrl, $fetch);
         }
 
         return $this->repositories[$repositoryUrl];

--- a/src/Service/Git/Log/GitLogService.php
+++ b/src/Service/Git/Log/GitLogService.php
@@ -84,8 +84,8 @@ class GitLogService implements LoggerAwareInterface
 
         $this->logger?->info(sprintf('Executing `%s` for `%s`', $command, $repository->getName()));
 
-        // get repository data without cache and execute command
-        $output = $this->gitRepositoryService->getRepository((string)$repository->getUrl())->execute($command);
+        // get repository data without cache, fetch new revisions and execute command
+        $output = $this->gitRepositoryService->getRepository((string)$repository->getUrl(), true)->execute($command);
 
         // get commits
         return $this->logParser->parse($repository, $output, $limit);

--- a/tests/Unit/Service/Git/GitRepositoryServiceTest.php
+++ b/tests/Unit/Service/Git/GitRepositoryServiceTest.php
@@ -51,7 +51,27 @@ class GitRepositoryServiceTest extends AbstractTestCase
 
         $repository->expects(static::once())->method('fetch')->with(null, ['--all']);
 
-        $this->service->getRepository($url);
+        $this->service->getRepository($url, true);
+    }
+
+    /**
+     * @covers ::getRepository
+     * @covers ::tryGetRepository
+     * @throws RepositoryException
+     */
+    public function testGetRepositoryWithoutCacheAndFetch(): void
+    {
+        $url        = 'http://my.repository.com';
+        $repository = $this->createMock(GitRepository::class);
+
+        // setup mocks
+        $this->filesystem->expects(static::once())->method('mkdir')->with(self::CACHE_DIRECTORY . '/git/');
+        $this->filesystem->expects(static::once())->method('exists')->willReturn(false);
+        $this->git->expects(static::once())->method('cloneRepository')->willReturn($repository);
+
+        $repository->expects(static::never())->method('fetch');
+
+        $this->service->getRepository($url, false);
     }
 
     /**
@@ -71,7 +91,7 @@ class GitRepositoryServiceTest extends AbstractTestCase
 
         $repository->expects(static::once())->method('fetch')->with(null, ['--all']);
 
-        $this->service->getRepository($url);
+        $this->service->getRepository($url, true);
     }
 
     /**

--- a/tests/Unit/Service/Git/Log/GitLogServiceTest.php
+++ b/tests/Unit/Service/Git/Log/GitLogServiceTest.php
@@ -114,7 +114,7 @@ class GitLogServiceTest extends AbstractTestCase
         $logBuilder->expects(self::once())->method('since')->willReturnSelf();
 
         $gitRepository->expects(static::once())->method('execute')->with($logBuilder)->willReturn('output');
-        $this->repositoryService->expects(static::once())->method('getRepository')->with('https://example.com')->willReturn($gitRepository);
+        $this->repositoryService->expects(static::once())->method('getRepository')->with('https://example.com', true)->willReturn($gitRepository);
         $this->logParser->expects(static::once())->method('parse')->with($repository, 'output', $limit)->willReturn($commits);
 
         $this->logFactory->getCommitsSince($repository, $revision, $limit);


### PR DESCRIPTION
Git fetch was invoked also invoked when doing regular git commands. Which is unnecessary bashing the git repository. Changed that git fetch is called _only_ when new revisions should be retrieved.