### PR TITLE
fix: white markdown background on dark mode

### DIFF
--- a/assets/styles/review.scss
+++ b/assets/styles/review.scss
@@ -35,8 +35,7 @@
 
 .diff-file__file-preview {
     padding: 5px 20px;
-    background-color: #efefef;
-    border: 1px solid #cccccc;
+    border: 1px solid var(--comment-border-color);
     margin-bottom: 5px;
 }
 


### PR DESCRIPTION
fixes the white background while previewing a README file.