### PR TITLE
Disable mailto in crontab

### DIFF
--- a/docker/php-fpm/cron/crontab
+++ b/docker/php-fpm/cron/crontab
@@ -1,3 +1,4 @@
+MAILTO=""
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
 HOME=/app
 0 */1 * * *     www-data     php bin/console mail --frequency=once-per-hour             2>&1


### PR DESCRIPTION
Disable crontab mails so the container stays small in size