### PR TITLE
Add absolute url for images in markdown 

### DIFF
--- a/src/EventSubscriber/MarkDown/AbsoluteImageUrlSubscriber.php
+++ b/src/EventSubscriber/MarkDown/AbsoluteImageUrlSubscriber.php
@@ -18,7 +18,7 @@ readonly class AbsoluteImageUrlSubscriber
     public function handle(DocumentParsedEvent $event): void
     {
         foreach ($this->iteratorFactory->iterate($event->getDocument()) as $node) {
-            if ($node instanceof Image === false || stripos($node->getUrl(), 'http') === 0) {
+            if ($node instanceof Image === false || preg_match('#^https?://#i', $node->getUrl()) === 1) {
                 continue;
             }
 

--- a/src/EventSubscriber/MarkDown/AbsoluteImageUrlSubscriber.php
+++ b/src/EventSubscriber/MarkDown/AbsoluteImageUrlSubscriber.php
@@ -1,0 +1,28 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\EventSubscriber\MarkDown;
+
+use DR\Review\Service\Markdown\DocumentNodeIteratorFactory;
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
+use Symfony\Component\EventDispatcher\Attribute\AsEventListener;
+
+#[AsEventListener(DocumentParsedEvent::class, 'handle')]
+readonly class AbsoluteImageUrlSubscriber
+{
+    public function __construct(private DocumentNodeIteratorFactory $iteratorFactory, private string $appAbsoluteUrl)
+    {
+    }
+
+    public function handle(DocumentParsedEvent $event): void
+    {
+        foreach ($this->iteratorFactory->iterate($event->getDocument()) as $node) {
+            if ($node instanceof Image === false || str_starts_with($node->getUrl(), 'http')) {
+                continue;
+            }
+
+            $node->setUrl(sprintf('%s/%s', rtrim($this->appAbsoluteUrl, '/'), ltrim($node->getUrl(), '/')));
+        }
+    }
+}

--- a/src/EventSubscriber/MarkDown/AbsoluteImageUrlSubscriber.php
+++ b/src/EventSubscriber/MarkDown/AbsoluteImageUrlSubscriber.php
@@ -18,7 +18,7 @@ readonly class AbsoluteImageUrlSubscriber
     public function handle(DocumentParsedEvent $event): void
     {
         foreach ($this->iteratorFactory->iterate($event->getDocument()) as $node) {
-            if ($node instanceof Image === false || str_starts_with($node->getUrl(), 'http')) {
+            if ($node instanceof Image === false || stripos($node->getUrl(), 'http') === 0) {
                 continue;
             }
 

--- a/src/Service/CodeReview/Comment/CommonMarkdownConverter.php
+++ b/src/Service/CodeReview/Comment/CommonMarkdownConverter.php
@@ -10,6 +10,7 @@ use League\CommonMark\Extension\CommonMark\CommonMarkCoreExtension;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use League\CommonMark\Extension\GithubFlavoredMarkdownExtension;
 use League\CommonMark\MarkdownConverter;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Spatie\CommonMarkHighlighter\FencedCodeRenderer;
 
 class CommonMarkdownConverter extends MarkdownConverter
@@ -33,7 +34,7 @@ class CommonMarkdownConverter extends MarkdownConverter
         "yaml",
     ];
 
-    public function __construct()
+    public function __construct(EventDispatcherInterface $eventDispatcher)
     {
         $environment = new Environment(
             [
@@ -46,6 +47,7 @@ class CommonMarkdownConverter extends MarkdownConverter
                 ]
             ]
         );
+        $environment->setEventDispatcher($eventDispatcher);
         $environment->addExtension(new CommonMarkCoreExtension());
         $environment->addExtension(new GithubFlavoredMarkdownExtension());
         $environment->addExtension(new EmojiExtension(EmojiDataProvider::full()));

--- a/src/Service/Markdown/DocumentNodeIteratorFactory.php
+++ b/src/Service/Markdown/DocumentNodeIteratorFactory.php
@@ -3,15 +3,14 @@ declare(strict_types=1);
 
 namespace DR\Review\Service\Markdown;
 
-use Generator;
 use League\CommonMark\Node\Node;
 
 class DocumentNodeIteratorFactory
 {
     /**
-     * @return Generator<Node>
+     * @return iterable<Node>
      */
-    public function iterate(Node $node): Generator
+    public function iterate(Node $node): iterable
     {
         yield $node;
 

--- a/src/Service/Markdown/DocumentNodeIteratorFactory.php
+++ b/src/Service/Markdown/DocumentNodeIteratorFactory.php
@@ -1,0 +1,22 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Service\Markdown;
+
+use Generator;
+use League\CommonMark\Node\Node;
+
+class DocumentNodeIteratorFactory
+{
+    /**
+     * @return Generator<Node>
+     */
+    public function iterate(Node $node): Generator
+    {
+        yield $node;
+
+        for ($next = $node->firstChild(); $next !== null; $next = $next->next()) {
+            yield from $this->iterate($next);
+        }
+    }
+}

--- a/tests/Unit/EventSubscriber/MarkDown/AbsoluteImageUrlSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/MarkDown/AbsoluteImageUrlSubscriberTest.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\EventSubscriber\MarkDown;
+
+use ArrayIterator;
+use DR\Review\EventSubscriber\MarkDown\AbsoluteImageUrlSubscriber;
+use DR\Review\Service\Markdown\DocumentNodeIteratorFactory;
+use DR\Review\Tests\AbstractTestCase;
+use League\CommonMark\Event\DocumentParsedEvent;
+use League\CommonMark\Extension\CommonMark\Node\Inline\Image;
+use League\CommonMark\Node\Block\Document;
+use League\CommonMark\Node\Node;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(AbsoluteImageUrlSubscriber::class)]
+class AbsoluteImageUrlSubscriberTest extends AbstractTestCase
+{
+    private DocumentNodeIteratorFactory&MockObject $iteratorFactory;
+    private AbsoluteImageUrlSubscriber             $subscriber;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->iteratorFactory = $this->createMock(DocumentNodeIteratorFactory::class);
+        $this->subscriber      = new AbsoluteImageUrlSubscriber($this->iteratorFactory, 'https://123view.com/');
+    }
+
+    public function testHandleNonImageNode(): void
+    {
+        $document    = $this->createMock(Document::class);
+        $defaultNode = $this->createMock(Node::class);
+        $iterator    = new ArrayIterator([$defaultNode]);
+
+        $this->iteratorFactory->expects($this->once())->method('iterate')->with($document)->willReturn($iterator);
+
+        $this->subscriber->handle(new DocumentParsedEvent($document));
+    }
+
+    public function testHandleAbsoluteImageNode(): void
+    {
+        $document  = $this->createMock(Document::class);
+        $imageNode = $this->createMock(Image::class);
+        $iterator  = new ArrayIterator([$imageNode]);
+
+        $imageNode->expects($this->once())->method('getUrl')->willReturn('https://123view.com/app/image/123.png');
+        $imageNode->expects($this->never())->method('setUrl');
+        $this->iteratorFactory->expects($this->once())->method('iterate')->with($document)->willReturn($iterator);
+
+        $this->subscriber->handle(new DocumentParsedEvent($document));
+    }
+
+    public function testHandleImageNode(): void
+    {
+        $document  = $this->createMock(Document::class);
+        $imageNode = $this->createMock(Image::class);
+        $iterator  = new ArrayIterator([$imageNode]);
+
+        $imageNode->expects($this->exactly(2))->method('getUrl')->willReturn('/app/image/123.png');
+        $imageNode->expects($this->once())->method('setUrl')->with('https://123view.com/app/image/123.png');
+        $this->iteratorFactory->expects($this->once())->method('iterate')->with($document)->willReturn($iterator);
+
+        $this->subscriber->handle(new DocumentParsedEvent($document));
+    }
+}

--- a/tests/Unit/EventSubscriber/MarkDown/AbsoluteImageUrlSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/MarkDown/AbsoluteImageUrlSubscriberTest.php
@@ -27,7 +27,7 @@ class AbsoluteImageUrlSubscriberTest extends AbstractTestCase
         $this->subscriber      = new AbsoluteImageUrlSubscriber($this->iteratorFactory, 'https://123view.com/');
     }
 
-    public function testHandleNonImageNode(): void
+    public function testHandleNonImageNodeShouldBeSkipped(): void
     {
         $document    = $this->createMock(Document::class);
         $defaultNode = $this->createMock(Node::class);
@@ -38,7 +38,7 @@ class AbsoluteImageUrlSubscriberTest extends AbstractTestCase
         $this->subscriber->handle(new DocumentParsedEvent($document));
     }
 
-    public function testHandleAbsoluteImageNode(): void
+    public function testHandleAbsoluteImageNodeShouldBeSkipped(): void
     {
         $document  = $this->createMock(Document::class);
         $imageNode = $this->createMock(Image::class);
@@ -51,7 +51,7 @@ class AbsoluteImageUrlSubscriberTest extends AbstractTestCase
         $this->subscriber->handle(new DocumentParsedEvent($document));
     }
 
-    public function testHandleImageNode(): void
+    public function testHandleImageUrlShouldBeAbsolute(): void
     {
         $document  = $this->createMock(Document::class);
         $imageNode = $this->createMock(Image::class);

--- a/tests/Unit/Service/CodeReview/Comment/CommonMarkdownConverterTest.php
+++ b/tests/Unit/Service/CodeReview/Comment/CommonMarkdownConverterTest.php
@@ -7,15 +7,24 @@ use DR\Review\Service\CodeReview\Comment\CommonMarkdownConverter;
 use DR\Review\Tests\AbstractTestCase;
 use League\CommonMark\Extension\CommonMark\Node\Block\FencedCode;
 use PHPUnit\Framework\Attributes\CoversClass;
+use Psr\EventDispatcher\EventDispatcherInterface;
 use Spatie\CommonMarkHighlighter\FencedCodeRenderer;
 
 #[CoversClass(CommonMarkdownConverter::class)]
 class CommonMarkdownConverterTest extends AbstractTestCase
 {
+    private CommonMarkdownConverter $converter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $this->converter = new CommonMarkdownConverter($eventDispatcher);
+    }
+
     public function testConstruct(): void
     {
-        $converter   = new CommonMarkdownConverter();
-        $environment = $converter->getEnvironment();
+        $environment = $this->converter->getEnvironment();
 
         $extension = $environment->getExtensions();
         static::assertCount(3, $extension);

--- a/tests/Unit/Service/Markdown/DocumentNodeIteratorFactoryTest.php
+++ b/tests/Unit/Service/Markdown/DocumentNodeIteratorFactoryTest.php
@@ -1,0 +1,39 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\Markdown;
+
+use DR\Review\Service\Markdown\DocumentNodeIteratorFactory;
+use DR\Review\Tests\AbstractTestCase;
+use League\CommonMark\Node\Node;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(DocumentNodeIteratorFactory::class)]
+class DocumentNodeIteratorFactoryTest extends AbstractTestCase
+{
+    private DocumentNodeIteratorFactory $factory;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->factory = new DocumentNodeIteratorFactory();
+    }
+
+    public function testIterate(): void
+    {
+        $nextNode = $this->createMock(Node::class);
+
+        $childNode = $this->createMock(Node::class);
+        $childNode->method('next')->willReturn($nextNode);
+
+        $node = $this->createMock(Node::class);
+        $node->method('firstChild')->willReturn($childNode);
+
+        $nodes = [];
+        foreach ($this->factory->iterate($node) as $iteratedNode) {
+            $nodes[] = $iteratedNode;
+        }
+
+        static::assertSame([$node, $childNode, $nextNode], $nodes);
+    }
+}


### PR DESCRIPTION
Currently pasting an image in comment field creates a relative link to the image. However in e-mails and external parties this image is then not visible. Update markdown parser to make Image an absolute url.