### PR TITLE
Remove underline on icons in anchor tags

### DIFF
--- a/assets/styles/icon.checkbox.scss
+++ b/assets/styles/icon.checkbox.scss
@@ -15,3 +15,7 @@
         display: inline;
     }
 }
+
+a.c-icon-checkbox {
+    text-decoration: none;
+}


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/e003673e-57ba-412f-af6a-c9ed43670e87)

After:
![image](https://github.com/user-attachments/assets/9196b60f-584e-4a57-896f-0eec2ae6f727)
