### PR TITLE
Remove generics from typescript files before highlighting

### DIFF
--- a/src/Service/CodeHighlight/HighlightedFilePreprocessor.php
+++ b/src/Service/CodeHighlight/HighlightedFilePreprocessor.php
@@ -1,0 +1,16 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Service\CodeHighlight;
+
+class HighlightedFilePreprocessor
+{
+    public function process(string $language, string $content): string
+    {
+        if ($language === "typescript") {
+            // currently 2025-08-21 highlightjs does not support typescript generics completely.
+            $content = preg_replace('#<\w+\\[]>#', '', $content);
+        }
+        return $content;
+    }
+}

--- a/src/Service/CodeHighlight/HighlightedFilePreprocessor.php
+++ b/src/Service/CodeHighlight/HighlightedFilePreprocessor.php
@@ -3,13 +3,15 @@ declare(strict_types=1);
 
 namespace DR\Review\Service\CodeHighlight;
 
+use DR\Utils\Assert;
+
 class HighlightedFilePreprocessor
 {
     public function process(string $language, string $content): string
     {
         if ($language === "typescript") {
             // currently 2025-08-21 highlightjs does not support typescript generics completely.
-            $content = preg_replace('#<\w+\[]>#', '', $content);
+            $content = Assert::string(preg_replace('#<\w+\[]>#', '', $content));
         }
         return $content;
     }

--- a/src/Service/CodeHighlight/HighlightedFilePreprocessor.php
+++ b/src/Service/CodeHighlight/HighlightedFilePreprocessor.php
@@ -9,7 +9,7 @@ class HighlightedFilePreprocessor
     {
         if ($language === "typescript") {
             // currently 2025-08-21 highlightjs does not support typescript generics completely.
-            $content = preg_replace('#<\w+\\[]>#', '', $content);
+            $content = preg_replace('#<\w+\[]>#', '', $content);
         }
         return $content;
     }

--- a/tests/Unit/Service/CodeHighlight/HighlightedFilePreprocessorTest.php
+++ b/tests/Unit/Service/CodeHighlight/HighlightedFilePreprocessorTest.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\CodeHighlight;
+
+use DR\Review\Service\CodeHighlight\HighlightedFilePreprocessor;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(HighlightedFilePreprocessor::class)]
+class HighlightedFilePreprocessorTest extends AbstractTestCase
+{
+    private HighlightedFilePreprocessor $preprocessor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->preprocessor = new HighlightedFilePreprocessor();
+    }
+
+    public function testProcessShouldSkipOtherLanguages(): void
+    {
+        static::assertSame('test <test[]>test', $this->preprocessor->process('foo', 'test <test[]>test'));
+    }
+
+    public function testProcessShouldRemoveTypescriptGenerics(): void
+    {
+        static::assertSame('test test', $this->preprocessor->process('typescript', 'test <test[]>test'));
+    }
+}


### PR DESCRIPTION
The highlightjs library doesn't fully support typescript generics (yet):

<img width="721" height="81" alt="image" src="https://github.com/user-attachments/assets/59b509ae-238b-4f4c-8136-57f70a67d75e" />

Without generics:
<img width="605" height="71" alt="image" src="https://github.com/user-attachments/assets/f8b8458f-10dc-4a71-9003-9e37dc818349" />
