### PR TITLE
Add review mcp tools

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,3 +87,7 @@ Use the specific test suites when working on particular areas to speed up feedba
 - `composer.json` - PHP dependencies and scripts
 - `phpstan.neon` - Static analysis configuration
 - `phpunit.xml.dist` - Test configuration
+
+## Code Navigation and Refactoring
+
+IMPORTANT: When applicable, prefer using phpstorm-index MCP tools for code navigation and refactoring.

--- a/config/packages/mcp.php
+++ b/config/packages/mcp.php
@@ -10,7 +10,7 @@ return App::config([
         'version'           => '1.0.0',
         'description'       => 'A code review and commit notification application',
         'client_transports' => ['http' => true],
-        'discovery'         => ['scan_dirs' => ['src/Service/Ai/Mcp']],
+        'discovery'         => ['scan_dirs' => ['src/Service/Ai/Mcp', 'src/Service/Ai/Tool']],
         'instructions'      => 'This server provides access to code reviews'
     ],
 ]);

--- a/config/packages/security.php
+++ b/config/packages/security.php
@@ -43,7 +43,7 @@ return App::config([
         'access_control'   => [
             ['path' => '^/app/assets/', 'roles' => AuthenticatedVoter::PUBLIC_ACCESS],
             ['path' => '^/app', 'roles' => AuthenticatedVoter::IS_AUTHENTICATED_FULLY],
-            ['path' => '^/_mcp', 'roles' => AuthenticatedVoter::IS_AUTHENTICATED_FULLY],
+            ['path' => '^/_mcp', 'roles' => [Roles::ROLE_USER]],
             ['path' => '^/log-viewer', 'roles' => [Roles::ROLE_ADMIN]],
         ],
     ],

--- a/docs/configure-mcp-server.md
+++ b/docs/configure-mcp-server.md
@@ -26,6 +26,11 @@ Edit `~/.copilot/mcp-config.json`
 ```
 
 ## Available tools
-- `get-current-user`: Returns the id, name and email of the currently authenticated user.
-- `get-code-review`: Find the first code review matching the given filters. All provided filters are applied as AND conditions. Returns null when no match is found.
-- `get-code-reviews`: Search for code reviews using optional filters. All provided filters are applied as AND conditions. Returns up to 50 results ordered by most recently updated.
+- `add_comment`: Add a comment to a code review at a specific file and line number. Optionally include a code suggestion.
+- `get_code_review_comments`: Get all comments on the given review. Returns a list of comments with their id, author, content, file path, line number and optionally a code suggestion.
+- `get_code_review_diff`: Get the diff for all the changes done in the review. Returns a list of files with their path, name and diff.
+- `get_code_review`: Find the first code review matching the given filters. All provided filters are applied as AND conditions. Returns null when no match is found.
+- `get_code_reviews`: Search for code reviews using optional filters. All provided filters are applied as AND conditions. Returns up to 50 results ordered by most recently updated.
+- `get_current_user`: Returns the id, name and email of the currently authenticated user.
+- `list_files`: List the files in the given directory path for the specified code review.
+- `read_file`: Reads the contents of a file for the given path and review. Returns the file contents as a string. Only searches in the git repository of the specified code review and will not find any dependencies.

--- a/src/Exception/Ai/CodeReviewNotFoundException.php
+++ b/src/Exception/Ai/CodeReviewNotFoundException.php
@@ -10,7 +10,7 @@ class CodeReviewNotFoundException extends RuntimeException implements ToolExecut
 {
     public function __construct(private readonly int $reviewId)
     {
-        parent::__construct();
+        parent::__construct('Code review not found: ' . $this->reviewId);
     }
 
     public function getToolCallResult(): string

--- a/src/Service/Ai/AddCommentService.php
+++ b/src/Service/Ai/AddCommentService.php
@@ -43,7 +43,7 @@ class AddCommentService
         $message = str_replace(':**', '**', $message);
 
         $this->aiLogger?->info(
-            'CodeReviewAddCommentTool: Adding comment to file "{filepath}" at line {line} in review {id}',
+            'AddCommentService: Adding comment to file "{filepath}" at line {line} in review {id}',
             ['id' => $review->getId(), 'filepath' => $filepath, 'line' => $lineNumber]
         );
 

--- a/src/Service/Ai/AddCommentService.php
+++ b/src/Service/Ai/AddCommentService.php
@@ -1,0 +1,67 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Service\Ai;
+
+use DR\Review\Entity\Review\Comment;
+use DR\Review\Entity\Review\LineReference;
+use DR\Review\Entity\Review\NotificationStatus;
+use DR\Review\Entity\Revision\Revision;
+use DR\Review\Entity\User\User;
+use DR\Review\Exception\Ai\CodeReviewNotFoundException;
+use DR\Review\Repository\Review\CodeReviewRepository;
+use DR\Review\Repository\Review\CommentRepository;
+use DR\Review\Service\CodeReview\CodeReviewRevisionService;
+use DR\Utils\Arrays;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockAwareTrait;
+
+class AddCommentService
+{
+    use ClockAwareTrait;
+
+    public function __construct(
+        private ?LoggerInterface $aiLogger,
+        private readonly CodeReviewRepository $repository,
+        private readonly CommentRepository $commentRepository,
+        private readonly CodeReviewRevisionService $reviewRevisionService
+    ) {
+    }
+
+    public function addComment(User $user, int $codeReviewId, string $filepath, int $lineNumber, string $message, ?string $codeSuggestion): void
+    {
+        $review = $this->repository->find($codeReviewId);
+        if ($review === null) {
+            throw new CodeReviewNotFoundException($codeReviewId);
+        }
+
+        if ($codeSuggestion !== null && $codeSuggestion !== '') {
+            $message .= "\n\n```\n" . $codeSuggestion . "\n```";
+        }
+
+        // markdown bold + : turn in to kiss emoticon. Replace it to bold only.
+        $message = str_replace(':**', '**', $message);
+
+        $this->aiLogger?->info(
+            'CodeReviewAddCommentTool: Adding comment to file "{filepath}" at line {line} in review {id}',
+            ['id' => $review->getId(), 'filepath' => $filepath, 'line' => $lineNumber]
+        );
+
+        /** @var Revision $revision */
+        $revision = Arrays::last($this->reviewRevisionService->getRevisions($review));
+
+        $comment = new Comment();
+        $comment->setFilePath($filepath);
+        $comment->setTag(null);
+        $comment->setLineReference(new LineReference($filepath, $filepath, $lineNumber, lineAfter: $lineNumber, headSha: $revision->getCommitHash()));
+        $comment->setReview($review);
+        $comment->setMessage($message);
+        $comment->setUser($user);
+        $comment->setNotificationStatus(NotificationStatus::all());
+        $comment->setCreateTimestamp($this->now()->getTimestamp());
+        $comment->setUpdateTimestamp($this->now()->getTimestamp());
+
+        $review->getComments()->add($comment);
+        $this->commentRepository->save($comment, true);
+    }
+}

--- a/src/Service/Ai/AiCodeReviewService.php
+++ b/src/Service/Ai/AiCodeReviewService.php
@@ -3,13 +3,9 @@ declare(strict_types=1);
 
 namespace DR\Review\Service\Ai;
 
-use DR\Review\Doctrine\Type\CodeReviewType;
-use DR\Review\Entity\Git\Diff\DiffComparePolicy;
 use DR\Review\Entity\Git\Diff\DiffFile;
 use DR\Review\Entity\Review\CodeReview;
-use DR\Review\Service\CodeReview\CodeReviewRevisionService;
-use DR\Review\Service\Git\Review\FileDiffOptions;
-use DR\Review\Service\Git\Review\ReviewDiffService\ReviewDiffServiceInterface;
+use DR\Review\Service\CodeReview\CodeReviewDiffService;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Platform\Message\Message;
@@ -27,8 +23,7 @@ class AiCodeReviewService
 
     public function __construct(
         private ?LoggerInterface $aiLogger,
-        private readonly ReviewDiffServiceInterface $diffService,
-        private readonly CodeReviewRevisionService $revisionService,
+        private readonly CodeReviewDiffService $diffService,
         private readonly AgentInterface $agent,
         private readonly AiCodeReviewFileFilter $fileFilter,
     ) {
@@ -39,14 +34,7 @@ class AiCodeReviewService
      */
     public function startCodeReview(CodeReview $review): int
     {
-        $options = new FileDiffOptions(5, DiffComparePolicy::IGNORE_EMPTY_LINES, includeRaw: true);
-
-        // gather files for review  revisions
-        if ($review->getType() === CodeReviewType::BRANCH) {
-            $files = $this->diffService->getDiffForBranch($review, [], (string)$review->getReferenceId(), $options);
-        } else {
-            $files = $this->diffService->getDiffForRevisions($review->getRepository(), $this->revisionService->getRevisions($review), $options);
-        }
+        $files = $this->diffService->getDiff($review);
 
         // filter out large and non-essential files
         $files = array_filter($files, $this->fileFilter);

--- a/src/Service/Ai/Mcp/CodeReviewAddCommentTool.php
+++ b/src/Service/Ai/Mcp/CodeReviewAddCommentTool.php
@@ -1,24 +1,21 @@
 <?php
 declare(strict_types=1);
 
-namespace DR\Review\Service\Ai\Tool;
+namespace DR\Review\Service\Ai\Mcp;
 
-use DR\Review\Repository\User\UserRepository;
+use DR\Review\Entity\User\User;
 use DR\Review\Service\Ai\AddCommentService;
 use DR\Utils\Assert;
-use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
+use Mcp\Capability\Attribute\McpTool;
 use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
+use Symfony\Bundle\SecurityBundle\Security;
 use Throwable;
 
-#[AsTool('add_comment', 'Add a comment to a code review at a specific file and line number. Optionally include a code suggestion.')]
+#[McpTool('add_comment', 'Add a comment to a code review at a specific file and line number. Optionally include a code suggestion.')]
 readonly class CodeReviewAddCommentTool
 {
-    public function __construct(
-        #[Autowire(env: 'AI_COMMENT_USER_ID')] private ?int $userId,
-        private UserRepository $userRepository,
-        private AddCommentService $commentService,
-    ) {
+    public function __construct(private Security $security, private AddCommentService $commentService)
+    {
     }
 
     /**
@@ -31,10 +28,8 @@ readonly class CodeReviewAddCommentTool
         #[Schema(description: 'The comment text to add, must be valid markdown')] string $message,
         #[Schema(description: 'The code suggestion to include in the comment, must be valid markdown')] ?string $codeSuggestion
     ): string {
-        $user = Assert::notNull($this->userRepository->find(Assert::notNull($this->userId)));
-
         $this->commentService->addComment(
-            $user,
+            Assert::isInstanceOf($this->security->getUser(), User::class),
             $codeReviewId,
             $filepath,
             $lineNumber,

--- a/src/Service/Ai/Mcp/GetCodeReviewDiffTool.php
+++ b/src/Service/Ai/Mcp/GetCodeReviewDiffTool.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Review\Service\Ai\Mcp;
+
+use DR\Review\Entity\Git\Diff\DiffFile;
+use DR\Review\Exception\Ai\CodeReviewNotFoundException;
+use DR\Review\Repository\Mcp\CodeReviewRepository;
+use DR\Review\Service\CodeReview\CodeReviewDiffService;
+use Mcp\Capability\Attribute\McpTool;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+use Throwable;
+
+#[McpTool('get-code-review-diff', 'Get the diff for all the changes done in the review')]
+readonly class GetCodeReviewDiffTool
+{
+    public function __construct(private CodeReviewRepository $reviewRepository, private CodeReviewDiffService $diffService)
+    {
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function __invoke(#[Schema(description: 'The review id of the code review', minimum: 1)] int $codeReviewId): string
+    {
+        $review = $this->reviewRepository->find($codeReviewId);
+        if ($review === null) {
+            throw new CodeReviewNotFoundException($codeReviewId);
+        }
+
+        $files = $this->diffService->getDiff($review);
+        if (count($files) === 0) {
+            return 'No changes found in this review.';
+        }
+
+        return implode("\n", array_map(static fn(DiffFile $file) => $file->raw, $files));
+    }
+}

--- a/src/Service/Ai/Mcp/GetCodeReviewDiffTool.php
+++ b/src/Service/Ai/Mcp/GetCodeReviewDiffTool.php
@@ -12,7 +12,7 @@ use Mcp\Capability\Attribute\McpTool;
 use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 use Throwable;
 
-#[McpTool('get-code-review-diff', 'Get the diff for all the changes done in the review')]
+#[McpTool('get_code_review_diff', 'Get the diff for all the changes done in the review')]
 readonly class GetCodeReviewDiffTool
 {
     public function __construct(private CodeReviewRepository $reviewRepository, private CodeReviewDiffService $diffService)

--- a/src/Service/Ai/Tool/CodeReviewAddCommentTool.php
+++ b/src/Service/Ai/Tool/CodeReviewAddCommentTool.php
@@ -14,6 +14,7 @@ use DR\Review\Repository\User\UserRepository;
 use DR\Review\Service\CodeReview\CodeReviewRevisionService;
 use DR\Utils\Arrays;
 use DR\Utils\Assert;
+use Mcp\Capability\Attribute\McpTool;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
@@ -21,6 +22,7 @@ use Symfony\Component\Clock\ClockAwareTrait;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
 use Throwable;
 
+#[McpTool('add_comment', 'Add a comment to a code review at a specific file and line number. Optionally include a code suggestion.')]
 #[AsTool('add_comment', 'Add a comment to a code review at a specific file and line number. Optionally include a code suggestion.')]
 class CodeReviewAddCommentTool
 {
@@ -46,11 +48,11 @@ class CodeReviewAddCommentTool
      * @throws Throwable
      */
     public function __invoke(
-        #[Schema(minimum: 1)] int $codeReviewId,
-        string $filepath,
-        #[Schema(minimum: 1)] int $lineNumber,
-        string $message,
-        ?string $codeSuggestion
+        #[Schema(description: 'The review id of the code review', minimum: 1)] int $codeReviewId,
+        #[Schema(description: 'The filepath of the file to comment on relative to the git repository root')] string $filepath,
+        #[Schema(description: 'The line number in the file to comment on', minimum: 1)] int $lineNumber,
+        #[Schema(description: 'The comment text to add, must be valid markdown')] string $message,
+        #[Schema(description: 'The code suggestion to include in the comment, must be valid markdown')] ?string $codeSuggestion
     ): string {
         $review = $this->repository->find($codeReviewId);
         if ($review === null) {

--- a/src/Service/Ai/Tool/CodeReviewAddCommentTool.php
+++ b/src/Service/Ai/Tool/CodeReviewAddCommentTool.php
@@ -25,7 +25,7 @@ readonly class CodeReviewAddCommentTool
      * @throws Throwable
      */
     public function __invoke(
-        #[Schema(description: 'The review id of the code review', minimum: 1)] int $codeReviewId,
+        #[Schema(description: 'The CODE_REVIEW_ID of the code review', minimum: 1)] int $codeReviewId,
         #[Schema(description: 'The filepath of the file to comment on relative to the git repository root')] string $filepath,
         #[Schema(description: 'The line number in the file to comment on', minimum: 1)] int $lineNumber,
         #[Schema(description: 'The comment text to add, must be valid markdown')] string $message,

--- a/src/Service/Ai/Tool/CodeReviewFileTool.php
+++ b/src/Service/Ai/Tool/CodeReviewFileTool.php
@@ -9,10 +9,16 @@ use DR\Review\Exception\RepositoryException;
 use DR\Review\Repository\Review\CodeReviewRepository;
 use DR\Review\Service\Git\Show\LockableGitShowService;
 use DR\Utils\Arrays;
+use Mcp\Capability\Attribute\McpResource;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
+#[McpResource(
+    'read_file',
+    'Reads the contents of a file for the given path and review. Returns the file contents as a string. Only searches in the git ' .
+    'repository of the specified code review and will not find any dependencies.'
+)]
 #[AsTool(
     'read_file',
     'Reads the contents of a file for the given path and review. Returns the file contents as a string. Only searches in the git ' .
@@ -28,13 +34,12 @@ class CodeReviewFileTool
     }
 
     /**
-     * @param int    $codeReviewId The CODE_REVIEW_ID of the review
-     * @param string $filepath     The path to the file to read
-     *
      * @throws RepositoryException
      */
-    public function __invoke(#[Schema(minimum: 1)] int $codeReviewId, string $filepath): string
-    {
+    public function __invoke(
+        #[Schema(description: 'The CODE_REVIEW_ID of the review', minimum: 1)] int $codeReviewId,
+        #[Schema(description: 'The path to the file to read relative to the root of the git repository')] string $filepath
+    ): string {
         $review = $this->repository->find($codeReviewId);
         if ($review === null) {
             throw new CodeReviewNotFoundException($codeReviewId);

--- a/src/Service/Ai/Tool/CodeReviewFileTool.php
+++ b/src/Service/Ai/Tool/CodeReviewFileTool.php
@@ -9,12 +9,12 @@ use DR\Review\Exception\RepositoryException;
 use DR\Review\Repository\Review\CodeReviewRepository;
 use DR\Review\Service\Git\Show\LockableGitShowService;
 use DR\Utils\Arrays;
-use Mcp\Capability\Attribute\McpResource;
+use Mcp\Capability\Attribute\McpTool;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 
-#[McpResource(
+#[McpTool(
     'read_file',
     'Reads the contents of a file for the given path and review. Returns the file contents as a string. Only searches in the git ' .
     'repository of the specified code review and will not find any dependencies.'

--- a/src/Service/Ai/Tool/CodeReviewListFilesTool.php
+++ b/src/Service/Ai/Tool/CodeReviewListFilesTool.php
@@ -8,11 +8,13 @@ use DR\Review\Exception\Ai\CodeReviewNotFoundException;
 use DR\Review\Repository\Review\CodeReviewRepository;
 use DR\Review\Service\Git\LsTree\LockableLsTreeService;
 use DR\Utils\Arrays;
+use Mcp\Capability\Attribute\McpTool;
 use Psr\Log\LoggerInterface;
 use Symfony\AI\Agent\Toolbox\Attribute\AsTool;
 use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 use Throwable;
 
+#[McpTool('list_files', 'List the files in the given directory path for the specified code review.')]
 #[AsTool('list_files', 'List the files in the given directory path for the specified code review.')]
 class CodeReviewListFilesTool
 {

--- a/src/Service/Ai/Tool/CurrentUserTool.php
+++ b/src/Service/Ai/Tool/CurrentUserTool.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DR\Review\Service\Ai\Mcp;
+namespace DR\Review\Service\Ai\Tool;
 
 use DR\Review\Service\User\UserEntityProvider;
 use Mcp\Capability\Attribute\McpTool;

--- a/src/Service/Ai/Tool/CurrentUserTool.php
+++ b/src/Service/Ai/Tool/CurrentUserTool.php
@@ -7,7 +7,7 @@ namespace DR\Review\Service\Ai\Tool;
 use DR\Review\Service\User\UserEntityProvider;
 use Mcp\Capability\Attribute\McpTool;
 
-#[McpTool('get-current-user', 'Returns the id, name and email of the currently authenticated user.')]
+#[McpTool('get_current_user', 'Returns the id, name and email of the currently authenticated user.')]
 class CurrentUserTool
 {
     public function __construct(private readonly UserEntityProvider $userEntityProvider)

--- a/src/Service/Ai/Tool/GetCodeReviewTool.php
+++ b/src/Service/Ai/Tool/GetCodeReviewTool.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DR\Review\Service\Ai\Mcp;
+namespace DR\Review\Service\Ai\Tool;
 
 use DR\Review\Controller\App\Review\ReviewController;
 use DR\Review\Doctrine\Type\CodeReviewStateType;

--- a/src/Service/Ai/Tool/GetCodeReviewTool.php
+++ b/src/Service/Ai/Tool/GetCodeReviewTool.php
@@ -14,7 +14,7 @@ use Mcp\Capability\Attribute\Schema;
 use Symfony\Component\Routing\RouterInterface;
 
 #[McpTool(
-    name       : 'get-code-review',
+    name       : 'get_code_review',
     description: 'Find the first code review matching the given filters. All provided filters are applied as AND conditions. ' .
     'Returns null when no match is found.'
 )]

--- a/src/Service/Ai/Tool/GetCodeReviewsTool.php
+++ b/src/Service/Ai/Tool/GetCodeReviewsTool.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace DR\Review\Service\Ai\Mcp;
+namespace DR\Review\Service\Ai\Tool;
 
 use DR\Review\Controller\App\Review\ReviewController;
 use DR\Review\Doctrine\Type\CodeReviewStateType;

--- a/src/Service/Ai/Tool/GetCodeReviewsTool.php
+++ b/src/Service/Ai/Tool/GetCodeReviewsTool.php
@@ -15,7 +15,7 @@ use Mcp\Capability\Attribute\Schema;
 use Symfony\Component\Routing\RouterInterface;
 
 #[McpTool(
-    'get-code-reviews',
+    'get_code_reviews',
     'Search for code reviews using optional filters. All provided filters are applied as AND conditions. ' .
     'Returns up to 50 results ordered by most recently updated.'
 )]

--- a/src/Service/Ai/Tool/GetCommentsTool.php
+++ b/src/Service/Ai/Tool/GetCommentsTool.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace DR\Review\Service\Ai\Tool;
 
 use DR\Review\Entity\Review\Comment;
+use DR\Review\Exception\Ai\CodeReviewNotFoundException;
 use DR\Review\Repository\Mcp\CodeReviewRepository;
 use InvalidArgumentException;
 use Mcp\Capability\Attribute\McpTool;
@@ -36,7 +37,7 @@ readonly class GetCommentsTool
     {
         $review = $this->reviewRepository->find($codeReviewId);
         if ($review === null) {
-            throw new InvalidArgumentException('Code review not found');
+            throw new CodeReviewNotFoundException($codeReviewId);
         }
 
         return array_map(

--- a/src/Service/Ai/Tool/GetCommentsTool.php
+++ b/src/Service/Ai/Tool/GetCommentsTool.php
@@ -53,7 +53,7 @@ readonly class GetCommentsTool
                     'name'   => $comment->getUser()->getName(),
                     'email'  => $comment->getUser()->getEmail(),
                 ],
-                'createdAt' => $comment->getCreateTimestamp()->format('c'),
+                'createdAt' => date('c', $comment->getCreateTimestamp()),
             ];
         }, $review->getComments());
     }

--- a/src/Service/Ai/Tool/GetCommentsTool.php
+++ b/src/Service/Ai/Tool/GetCommentsTool.php
@@ -22,12 +22,13 @@ readonly class GetCommentsTool
      *     commentId: int,
      *     message: string,
      *     state: string,
-     *     file: string,
+     *     file: string|null,
      *     line: int,
+     *     createdAt: string,
      *     author: array{
      *         userId: int,
      *         name: string,
-     *         email: string
+     *         email: non-empty-string
      *     },
      * }>
      */
@@ -43,7 +44,7 @@ readonly class GetCommentsTool
             $lineReference = $comment->getLineReference();
 
             return [
-                'commentId' => $comment->getId(),
+                'commentId' => (int)$comment->getId(),
                 'message'   => $comment->getMessage(),
                 'state'     => $comment->getState(),
                 'file'      => $lineReference->newPath ?? $lineReference->oldPath,

--- a/src/Service/Ai/Tool/GetCommentsTool.php
+++ b/src/Service/Ai/Tool/GetCommentsTool.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Capability\Attribute\Schema;
 
-#[McpTool('get_comments_for_reviews', 'Get all comments on the given review')]
+#[McpTool('get_code_review_comments', 'Get all comments on the given review')]
 readonly class GetCommentsTool
 {
     public function __construct(private CodeReviewRepository $reviewRepository)

--- a/src/Service/Ai/Tool/GetCommentsTool.php
+++ b/src/Service/Ai/Tool/GetCommentsTool.php
@@ -57,7 +57,7 @@ readonly class GetCommentsTool
                     'createdAt' => date('c', $comment->getCreateTimestamp()),
                 ];
             },
-            $review->getComments()
+            $review->getComments()->toArray()
         );
     }
 }

--- a/src/Service/Ai/Tool/GetCommentsTool.php
+++ b/src/Service/Ai/Tool/GetCommentsTool.php
@@ -7,7 +7,6 @@ namespace DR\Review\Service\Ai\Tool;
 use DR\Review\Entity\Review\Comment;
 use DR\Review\Exception\Ai\CodeReviewNotFoundException;
 use DR\Review\Repository\Mcp\CodeReviewRepository;
-use InvalidArgumentException;
 use Mcp\Capability\Attribute\McpTool;
 use Mcp\Capability\Attribute\Schema;
 
@@ -25,12 +24,12 @@ readonly class GetCommentsTool
      *     state: string,
      *     file: string|null,
      *     line: int,
-     *     createdAt: string,
      *     author: array{
      *         userId: int,
      *         name: string,
      *         email: non-empty-string
      *     },
+     *     createdAt: string
      * }>
      */
     public function __invoke(#[Schema(description: 'The CODE_REVIEW_ID of the code review')] int $codeReviewId): array

--- a/src/Service/Ai/Tool/GetCommentsTool.php
+++ b/src/Service/Ai/Tool/GetCommentsTool.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Review\Service\Ai\Tool;
+
+use DR\Review\Entity\Review\Comment;
+use DR\Review\Repository\Mcp\CodeReviewRepository;
+use InvalidArgumentException;
+use Mcp\Capability\Attribute\McpTool;
+use Mcp\Capability\Attribute\Schema;
+
+#[McpTool('get_comments_for_reviews', 'Get all comments on the given review')]
+readonly class GetCommentsTool
+{
+    public function __construct(private CodeReviewRepository $reviewRepository)
+    {
+    }
+
+    /**
+     * @return array<array{
+     *     commentId: int,
+     *     message: string,
+     *     state: string,
+     *     file: string,
+     *     line: int,
+     *     author: array{
+     *         userId: int,
+     *         name: string,
+     *         email: string
+     *     },
+     * }>
+     */
+    public function __invoke(
+        #[Schema(description: 'The CODE_REVIEW_ID of the code review')] int $codeReviewId,
+    ): array {
+        $review = $this->reviewRepository->find($codeReviewId);
+        if ($review === null) {
+            throw new InvalidArgumentException('Code review not found');
+        }
+
+        return array_map(static function (Comment $comment) {
+            $lineReference = $comment->getLineReference();
+
+            return [
+                'commentId' => $comment->getId(),
+                'message'   => $comment->getMessage(),
+                'state'     => $comment->getState(),
+                'file'      => $lineReference->newPath ?? $lineReference->oldPath,
+                'line'      => $lineReference->lineAfter,
+                'author'    => [
+                    'userId' => $comment->getUser()->getId(),
+                    'name'   => $comment->getUser()->getName(),
+                    'email'  => $comment->getUser()->getEmail(),
+                ],
+                'createdAt' => $comment->getCreateTimestamp()->format('c'),
+            ];
+        }, $review->getComments());
+    }
+}

--- a/src/Service/Ai/Tool/GetCommentsTool.php
+++ b/src/Service/Ai/Tool/GetCommentsTool.php
@@ -32,30 +32,32 @@ readonly class GetCommentsTool
      *     },
      * }>
      */
-    public function __invoke(
-        #[Schema(description: 'The CODE_REVIEW_ID of the code review')] int $codeReviewId,
-    ): array {
+    public function __invoke(#[Schema(description: 'The CODE_REVIEW_ID of the code review')] int $codeReviewId): array
+    {
         $review = $this->reviewRepository->find($codeReviewId);
         if ($review === null) {
             throw new InvalidArgumentException('Code review not found');
         }
 
-        return array_map(static function (Comment $comment) {
-            $lineReference = $comment->getLineReference();
+        return array_map(
+            static function (Comment $comment) {
+                $lineReference = $comment->getLineReference();
 
-            return [
-                'commentId' => (int)$comment->getId(),
-                'message'   => $comment->getMessage(),
-                'state'     => $comment->getState(),
-                'file'      => $lineReference->newPath ?? $lineReference->oldPath,
-                'line'      => $lineReference->lineAfter,
-                'author'    => [
-                    'userId' => $comment->getUser()->getId(),
-                    'name'   => $comment->getUser()->getName(),
-                    'email'  => $comment->getUser()->getEmail(),
-                ],
-                'createdAt' => date('c', $comment->getCreateTimestamp()),
-            ];
-        }, $review->getComments());
+                return [
+                    'commentId' => (int)$comment->getId(),
+                    'message'   => $comment->getMessage(),
+                    'state'     => $comment->getState(),
+                    'file'      => $lineReference->newPath ?? $lineReference->oldPath,
+                    'line'      => $lineReference->lineAfter,
+                    'author'    => [
+                        'userId' => $comment->getUser()->getId(),
+                        'name'   => $comment->getUser()->getName(),
+                        'email'  => $comment->getUser()->getEmail(),
+                    ],
+                    'createdAt' => date('c', $comment->getCreateTimestamp()),
+                ];
+            },
+            $review->getComments()
+        );
     }
 }

--- a/src/Service/CodeReview/CodeReviewDiffService.php
+++ b/src/Service/CodeReview/CodeReviewDiffService.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Service\CodeReview;
+
+use DR\Review\Doctrine\Type\CodeReviewType;
+use DR\Review\Entity\Git\Diff\DiffComparePolicy;
+use DR\Review\Entity\Git\Diff\DiffFile;
+use DR\Review\Entity\Review\CodeReview;
+use DR\Review\Service\Git\Review\FileDiffOptions;
+use DR\Review\Service\Git\Review\ReviewDiffService\ReviewDiffServiceInterface;
+use Throwable;
+
+readonly class CodeReviewDiffService
+{
+    public function __construct(private ReviewDiffServiceInterface $diffService, private CodeReviewRevisionService $revisionService)
+    {
+    }
+
+    /**
+     * @return DiffFile[]
+     * @throws Throwable
+     */
+    public function getDiff(CodeReview $review): array
+    {
+        $options = new FileDiffOptions(5, DiffComparePolicy::IGNORE_EMPTY_LINES, includeRaw: true);
+
+        // gather files for review revisions
+        if ($review->getType() === CodeReviewType::BRANCH) {
+            return $this->diffService->getDiffForBranch($review, [], (string)$review->getReferenceId(), $options);
+        }
+
+        return $this->diffService->getDiffForRevisions($review->getRepository(), $this->revisionService->getRevisions($review), $options);
+    }
+}

--- a/tests/Functional/Mcp/GetCodeReviewToolTest.php
+++ b/tests/Functional/Mcp/GetCodeReviewToolTest.php
@@ -42,7 +42,7 @@ class GetCodeReviewToolTest extends AbstractFunctionalTestCase
                 'id'      => 2,
                 'method'  => 'tools/call',
                 'params'  => [
-                    'name'      => 'get-code-review',
+                    'name'      => 'get_code_review',
                     'arguments' => ['title' => 'title'],
                 ],
             ]),

--- a/tests/Functional/Mcp/GetCodeReviewToolTest.php
+++ b/tests/Functional/Mcp/GetCodeReviewToolTest.php
@@ -75,7 +75,7 @@ class GetCodeReviewToolTest extends AbstractFunctionalTestCase
                 'id'      => 2,
                 'method'  => 'tools/call',
                 'params'  => [
-                    'name'      => 'get-code-review',
+                    'name'      => 'get_code_review',
                     'arguments' => ['title' => 'nonexistent-title'],
                 ],
             ]),

--- a/tests/Functional/Mcp/McpServerTest.php
+++ b/tests/Functional/Mcp/McpServerTest.php
@@ -105,9 +105,16 @@ class McpServerTest extends AbstractFunctionalTestCase
         static::assertIsArray($data['result']['tools']);
 
         $toolNames = array_column($data['result']['tools'], 'name');
-        static::assertContains('get-code-review', $toolNames);
-        static::assertContains('get-code-reviews', $toolNames);
-        static::assertContains('get-current-user', $toolNames);
+        static::assertCount(8, $toolNames);
+        static::assertContains('get_code_review', $toolNames);
+        static::assertContains('get_code_reviews', $toolNames);
+        static::assertContains('get_code_review_diff', $toolNames);
+        static::assertContains('get_code_review_comments', $toolNames);
+        static::assertContains('get_current_user', $toolNames);
+        static::assertContains('add_comment', $toolNames);
+        static::assertContains('read_file', $toolNames);
+        static::assertContains('list_files', $toolNames);
+
     }
 
     /**

--- a/tests/Functional/Mcp/McpServerTest.php
+++ b/tests/Functional/Mcp/McpServerTest.php
@@ -114,7 +114,6 @@ class McpServerTest extends AbstractFunctionalTestCase
         static::assertContains('add_comment', $toolNames);
         static::assertContains('read_file', $toolNames);
         static::assertContains('list_files', $toolNames);
-
     }
 
     /**

--- a/tests/Unit/Service/Ai/AddCommentServiceTest.php
+++ b/tests/Unit/Service/Ai/AddCommentServiceTest.php
@@ -54,9 +54,9 @@ class AddCommentServiceTest extends AbstractTestCase
     public function testAddCommentShouldAddCommentWithoutSuggestion(): void
     {
         $repositoryEntity = new Repository();
-        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('abc123');
-        $review           = (new CodeReview())->setId(456);
-        $user             = (new User())->setId(1);
+        $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
+        $review           = new CodeReview()->setId(456);
+        $user             = new User()->setId(1);
 
         $this->repository->expects($this->once())->method('find')->with(456)->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->with($review)->willReturn([$revision]);
@@ -84,8 +84,8 @@ class AddCommentServiceTest extends AbstractTestCase
     public function testAddCommentShouldAppendCodeSuggestion(): void
     {
         $repositoryEntity = new Repository();
-        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('def456');
-        $review           = (new CodeReview())->setId(1);
+        $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('def456');
+        $review           = new CodeReview()->setId(1);
 
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
@@ -101,8 +101,8 @@ class AddCommentServiceTest extends AbstractTestCase
     public function testAddCommentShouldSkipEmptyCodeSuggestion(): void
     {
         $repositoryEntity = new Repository();
-        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('abc123');
-        $review           = (new CodeReview())->setId(1);
+        $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
+        $review           = new CodeReview()->setId(1);
 
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
@@ -118,8 +118,8 @@ class AddCommentServiceTest extends AbstractTestCase
     public function testAddCommentShouldReplaceKissEmoticonInMessage(): void
     {
         $repositoryEntity = new Repository();
-        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('abc123');
-        $review           = (new CodeReview())->setId(1);
+        $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
+        $review           = new CodeReview()->setId(1);
 
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
@@ -135,8 +135,8 @@ class AddCommentServiceTest extends AbstractTestCase
     public function testAddCommentShouldSetTimestamps(): void
     {
         $repositoryEntity = new Repository();
-        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('abc123');
-        $review           = (new CodeReview())->setId(1);
+        $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
+        $review           = new CodeReview()->setId(1);
 
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
@@ -153,7 +153,7 @@ class AddCommentServiceTest extends AbstractTestCase
     public function testAddCommentShouldWorkWithNullLogger(): void
     {
         $repositoryEntity = new Repository();
-        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('abc123');
+        $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
         $review           = new CodeReview();
 
         $service = new AddCommentService(null, $this->repository, $this->commentRepository, $this->reviewRevisionService);

--- a/tests/Unit/Service/Ai/AddCommentServiceTest.php
+++ b/tests/Unit/Service/Ai/AddCommentServiceTest.php
@@ -73,7 +73,6 @@ class AddCommentServiceTest extends AbstractTestCase
         static::assertSame($review, $comment->getReview());
 
         $ref = $comment->getLineReference();
-        static::assertNotNull($ref);
         static::assertSame('src/Service/Test.php', $ref->oldPath);
         static::assertSame('src/Service/Test.php', $ref->newPath);
         static::assertSame(25, $ref->line);

--- a/tests/Unit/Service/Ai/AddCommentServiceTest.php
+++ b/tests/Unit/Service/Ai/AddCommentServiceTest.php
@@ -1,0 +1,170 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\Ai;
+
+use DR\Review\Entity\Repository\Repository;
+use DR\Review\Entity\Review\CodeReview;
+use DR\Review\Entity\Review\Comment;
+use DR\Review\Entity\Revision\Revision;
+use DR\Review\Entity\User\User;
+use DR\Review\Exception\Ai\CodeReviewNotFoundException;
+use DR\Review\Repository\Review\CodeReviewRepository;
+use DR\Review\Repository\Review\CommentRepository;
+use DR\Review\Service\Ai\AddCommentService;
+use DR\Review\Service\CodeReview\CodeReviewRevisionService;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Clock\MockClock;
+
+#[CoversClass(AddCommentService::class)]
+class AddCommentServiceTest extends AbstractTestCase
+{
+    private CodeReviewRepository&MockObject      $repository;
+    private CommentRepository&MockObject         $commentRepository;
+    private CodeReviewRevisionService&MockObject $reviewRevisionService;
+    private AddCommentService                    $service;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->repository            = $this->createMock(CodeReviewRepository::class);
+        $this->commentRepository     = $this->createMock(CommentRepository::class);
+        $this->reviewRevisionService = $this->createMock(CodeReviewRevisionService::class);
+        $this->service               = new AddCommentService(
+            $this->logger,
+            $this->repository,
+            $this->commentRepository,
+            $this->reviewRevisionService
+        );
+        $this->service->setClock(new MockClock('2024-01-01T12:00:00+00:00'));
+    }
+
+    public function testAddCommentShouldThrowExceptionWhenReviewNotFound(): void
+    {
+        $this->repository->expects($this->once())->method('find')->with(123)->willReturn(null);
+        $this->commentRepository->expects($this->never())->method('save');
+        $this->reviewRevisionService->expects($this->never())->method('getRevisions');
+
+        $this->expectException(CodeReviewNotFoundException::class);
+        $this->service->addComment(new User(), 123, 'src/file.php', 10, 'comment', null);
+    }
+
+    public function testAddCommentShouldAddCommentWithoutSuggestion(): void
+    {
+        $repositoryEntity = new Repository();
+        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('abc123');
+        $review           = (new CodeReview())->setId(456);
+        $user             = (new User())->setId(1);
+
+        $this->repository->expects($this->once())->method('find')->with(456)->willReturn($review);
+        $this->reviewRevisionService->expects($this->once())->method('getRevisions')->with($review)->willReturn([$revision]);
+        $this->commentRepository->expects($this->once())->method('save')->with(self::isInstanceOf(Comment::class), true);
+
+        $this->service->addComment($user, 456, 'src/Service/Test.php', 25, 'Needs refactoring', null);
+
+        static::assertCount(1, $review->getComments());
+        $comment = $review->getComments()->first();
+        static::assertInstanceOf(Comment::class, $comment);
+        static::assertSame('src/Service/Test.php', $comment->getFilePath());
+        static::assertSame('Needs refactoring', $comment->getMessage());
+        static::assertSame($user, $comment->getUser());
+        static::assertSame($review, $comment->getReview());
+
+        $ref = $comment->getLineReference();
+        static::assertNotNull($ref);
+        static::assertSame('src/Service/Test.php', $ref->oldPath);
+        static::assertSame('src/Service/Test.php', $ref->newPath);
+        static::assertSame(25, $ref->line);
+        static::assertSame(25, $ref->lineAfter);
+        static::assertSame('abc123', $ref->headSha);
+    }
+
+    public function testAddCommentShouldAppendCodeSuggestion(): void
+    {
+        $repositoryEntity = new Repository();
+        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('def456');
+        $review           = (new CodeReview())->setId(1);
+
+        $this->repository->expects($this->once())->method('find')->willReturn($review);
+        $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
+        $this->commentRepository->expects($this->once())->method('save');
+
+        $this->service->addComment(new User(), 1, 'file.php', 5, 'Use this instead', 'return $value;');
+
+        $comment = $review->getComments()->first();
+        static::assertInstanceOf(Comment::class, $comment);
+        static::assertSame("Use this instead\n\n```\nreturn \$value;\n```", $comment->getMessage());
+    }
+
+    public function testAddCommentShouldSkipEmptyCodeSuggestion(): void
+    {
+        $repositoryEntity = new Repository();
+        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('abc123');
+        $review           = (new CodeReview())->setId(1);
+
+        $this->repository->expects($this->once())->method('find')->willReturn($review);
+        $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
+        $this->commentRepository->expects($this->once())->method('save');
+
+        $this->service->addComment(new User(), 1, 'file.php', 5, 'Just a comment', '');
+
+        $comment = $review->getComments()->first();
+        static::assertInstanceOf(Comment::class, $comment);
+        static::assertSame('Just a comment', $comment->getMessage());
+    }
+
+    public function testAddCommentShouldReplaceKissEmoticonInMessage(): void
+    {
+        $repositoryEntity = new Repository();
+        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('abc123');
+        $review           = (new CodeReview())->setId(1);
+
+        $this->repository->expects($this->once())->method('find')->willReturn($review);
+        $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
+        $this->commentRepository->expects($this->once())->method('save');
+
+        $this->service->addComment(new User(), 1, 'file.php', 5, '**Note:**bold text', null);
+
+        $comment = $review->getComments()->first();
+        static::assertInstanceOf(Comment::class, $comment);
+        static::assertSame('**Note**bold text', $comment->getMessage());
+    }
+
+    public function testAddCommentShouldSetTimestamps(): void
+    {
+        $repositoryEntity = new Repository();
+        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('abc123');
+        $review           = (new CodeReview())->setId(1);
+
+        $this->repository->expects($this->once())->method('find')->willReturn($review);
+        $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
+        $this->commentRepository->expects($this->once())->method('save');
+
+        $this->service->addComment(new User(), 1, 'file.php', 5, 'comment', null);
+
+        $comment = $review->getComments()->first();
+        static::assertInstanceOf(Comment::class, $comment);
+        static::assertSame(1704110400, $comment->getCreateTimestamp());
+        static::assertSame(1704110400, $comment->getUpdateTimestamp());
+    }
+
+    public function testAddCommentShouldWorkWithNullLogger(): void
+    {
+        $repositoryEntity = new Repository();
+        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('abc123');
+        $review           = new CodeReview();
+
+        $service = new AddCommentService(null, $this->repository, $this->commentRepository, $this->reviewRevisionService);
+        $service->setClock(new MockClock('2024-01-01T12:00:00+00:00'));
+
+        $this->repository->expects($this->once())->method('find')->willReturn($review);
+        $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
+        $this->commentRepository->expects($this->once())->method('save');
+
+        $service->addComment(new User(), 1, 'file.php', 5, 'comment', null);
+
+        static::assertCount(1, $review->getComments());
+    }
+}

--- a/tests/Unit/Service/Ai/AiCodeReviewServiceTest.php
+++ b/tests/Unit/Service/Ai/AiCodeReviewServiceTest.php
@@ -3,62 +3,47 @@ declare(strict_types=1);
 
 namespace DR\Review\Tests\Unit\Service\Ai;
 
-use DR\Review\Doctrine\Type\CodeReviewType;
 use DR\Review\Entity\Git\Diff\DiffFile;
-use DR\Review\Entity\Repository\Repository;
 use DR\Review\Entity\Review\CodeReview;
-use DR\Review\Entity\Revision\Revision;
 use DR\Review\Service\Ai\AiCodeReviewFileFilter;
 use DR\Review\Service\Ai\AiCodeReviewService;
-use DR\Review\Service\CodeReview\CodeReviewRevisionService;
-use DR\Review\Service\Git\Review\FileDiffOptions;
-use DR\Review\Service\Git\Review\ReviewDiffService\ReviewDiffServiceInterface;
+use DR\Review\Service\CodeReview\CodeReviewDiffService;
 use DR\Review\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use RuntimeException;
 use Symfony\AI\Agent\AgentInterface;
 use Symfony\AI\Platform\Message\MessageBag;
+use Throwable;
 
 #[CoversClass(AiCodeReviewService::class)]
 class AiCodeReviewServiceTest extends AbstractTestCase
 {
-    private ReviewDiffServiceInterface&MockObject   $diffService;
-    private CodeReviewRevisionService&MockObject    $revisionService;
-    private AgentInterface&MockObject               $agent;
-    private AiCodeReviewFileFilter&MockObject       $fileFilter;
-    private AiCodeReviewService                     $service;
+    private CodeReviewDiffService&MockObject  $diffService;
+    private AgentInterface&MockObject         $agent;
+    private AiCodeReviewFileFilter&MockObject $fileFilter;
+    private AiCodeReviewService               $service;
 
     public function setUp(): void
     {
         parent::setUp();
-        $this->diffService     = $this->createMock(ReviewDiffServiceInterface::class);
-        $this->revisionService = $this->createMock(CodeReviewRevisionService::class);
-        $this->agent           = $this->createMock(AgentInterface::class);
-        $this->fileFilter      = $this->createMock(AiCodeReviewFileFilter::class);
-        $this->service         = new AiCodeReviewService(
-            $this->logger,
-            $this->diffService,
-            $this->revisionService,
-            $this->agent,
-            $this->fileFilter
-        );
+        $this->diffService = $this->createMock(CodeReviewDiffService::class);
+        $this->agent       = $this->createMock(AgentInterface::class);
+        $this->fileFilter  = $this->createMock(AiCodeReviewFileFilter::class);
+        $this->service     = new AiCodeReviewService($this->logger, $this->diffService, $this->agent, $this->fileFilter);
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testStartCodeReviewShouldReturnSuccessOnHappyFlow(): void
     {
-        $repository = new Repository();
-        $revision   = (new Revision())->setRepository($repository);
-        $review     = (new CodeReview())->setId(123)->setRepository($repository)->setType(CodeReviewType::COMMITS);
+        $review = new CodeReview()->setId(123);
 
         $diffFile      = new DiffFile();
         $diffFile->raw = 'diff content';
 
-        $this->revisionService->expects($this->once())->method('getRevisions')->with($review)->willReturn([$revision]);
-        $this->diffService->expects($this->once())
-            ->method('getDiffForRevisions')
-            ->with($repository, [$revision], self::isInstanceOf(FileDiffOptions::class))
-            ->willReturn([$diffFile]);
+        $this->diffService->expects($this->once())->method('getDiff')->with($review)->willReturn([$diffFile]);
         $this->fileFilter->expects($this->once())->method('__invoke')->with($diffFile)->willReturn(true);
         $this->agent->expects($this->once())->method('call')->with(self::isInstanceOf(MessageBag::class));
 
@@ -67,19 +52,15 @@ class AiCodeReviewServiceTest extends AbstractTestCase
         static::assertSame(AiCodeReviewService::RESULT_SUCCESS, $result);
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testStartCodeReviewShouldReturnNoFilesWhenAllFilesFiltered(): void
     {
-        $repository = new Repository();
-        $revision   = (new Revision())->setRepository($repository);
-        $review     = (new CodeReview())->setId(456)->setRepository($repository)->setType(CodeReviewType::COMMITS);
-
+        $review   = new CodeReview()->setId(456);
         $diffFile = new DiffFile();
 
-        $this->revisionService->expects($this->once())->method('getRevisions')->with($review)->willReturn([$revision]);
-        $this->diffService->expects($this->once())
-            ->method('getDiffForRevisions')
-            ->with($repository, [$revision], self::isInstanceOf(FileDiffOptions::class))
-            ->willReturn([$diffFile]);
+        $this->diffService->expects($this->once())->method('getDiff')->with($review)->willReturn([$diffFile]);
         $this->fileFilter->expects($this->once())->method('__invoke')->with($diffFile)->willReturn(false);
         $this->agent->expects($this->never())->method('call');
 
@@ -88,46 +69,22 @@ class AiCodeReviewServiceTest extends AbstractTestCase
         static::assertSame(AiCodeReviewService::RESULT_NO_FILES, $result);
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testStartCodeReviewShouldReturnFailureWhenAgentThrowsException(): void
     {
-        $repository = new Repository();
-        $revision   = (new Revision())->setRepository($repository);
-        $review     = (new CodeReview())->setId(789)->setRepository($repository)->setType(CodeReviewType::COMMITS);
+        $review = new CodeReview()->setId(789);
 
         $diffFile      = new DiffFile();
         $diffFile->raw = 'diff content';
 
-        $this->revisionService->expects($this->once())->method('getRevisions')->with($review)->willReturn([$revision]);
-        $this->diffService->expects($this->once())
-            ->method('getDiffForRevisions')
-            ->with($repository, [$revision], self::isInstanceOf(FileDiffOptions::class))
-            ->willReturn([$diffFile]);
+        $this->diffService->expects($this->once())->method('getDiff')->with($review)->willReturn([$diffFile]);
         $this->fileFilter->expects($this->once())->method('__invoke')->with($diffFile)->willReturn(true);
         $this->agent->expects($this->once())->method('call')->willThrowException(new RuntimeException('Agent error'));
 
         $result = $this->service->startCodeReview($review);
 
         static::assertSame(AiCodeReviewService::RESULT_FAILURE, $result);
-    }
-
-    public function testStartCodeReviewBranchReview(): void
-    {
-        $repository = new Repository();
-        $review     = (new CodeReview())->setId(123)->setRepository($repository)->setType(CodeReviewType::BRANCH)->setReferenceId('feature-branch');
-
-        $diffFile      = new DiffFile();
-        $diffFile->raw = 'diff content';
-
-        $this->revisionService->expects($this->never())->method('getRevisions');
-        $this->diffService->expects($this->once())
-            ->method('getDiffForBranch')
-            ->with($review, [], 'feature-branch', self::isInstanceOf(FileDiffOptions::class))
-            ->willReturn([$diffFile]);
-        $this->fileFilter->expects($this->once())->method('__invoke')->with($diffFile)->willReturn(true);
-        $this->agent->expects($this->once())->method('call')->with(self::isInstanceOf(MessageBag::class));
-
-        $result = $this->service->startCodeReview($review);
-
-        static::assertSame(AiCodeReviewService::RESULT_SUCCESS, $result);
     }
 }

--- a/tests/Unit/Service/Ai/Mcp/CodeReviewAddCommentToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/CodeReviewAddCommentToolTest.php
@@ -10,6 +10,7 @@ use DR\Review\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\SecurityBundle\Security;
+use Throwable;
 
 #[CoversClass(CodeReviewAddCommentTool::class)]
 class CodeReviewAddCommentToolTest extends AbstractTestCase
@@ -26,6 +27,9 @@ class CodeReviewAddCommentToolTest extends AbstractTestCase
         $this->tool           = new CodeReviewAddCommentTool($this->security, $this->commentService);
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testInvokeShouldAddCommentSuccessfully(): void
     {
         $user = new User();
@@ -38,6 +42,9 @@ class CodeReviewAddCommentToolTest extends AbstractTestCase
         static::assertSame('Comment added successfully.', $result);
     }
 
+    /**
+     * @throws Throwable
+     */
     public function testInvokeShouldAddCommentWithoutSuggestion(): void
     {
         $user = new User();

--- a/tests/Unit/Service/Ai/Mcp/CodeReviewAddCommentToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/CodeReviewAddCommentToolTest.php
@@ -1,0 +1,52 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\Ai\Mcp;
+
+use DR\Review\Entity\User\User;
+use DR\Review\Service\Ai\AddCommentService;
+use DR\Review\Service\Ai\Mcp\CodeReviewAddCommentTool;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\SecurityBundle\Security;
+
+#[CoversClass(CodeReviewAddCommentTool::class)]
+class CodeReviewAddCommentToolTest extends AbstractTestCase
+{
+    private Security&MockObject            $security;
+    private AddCommentService&MockObject   $commentService;
+    private CodeReviewAddCommentTool       $tool;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->security       = $this->createMock(Security::class);
+        $this->commentService = $this->createMock(AddCommentService::class);
+        $this->tool           = new CodeReviewAddCommentTool($this->security, $this->commentService);
+    }
+
+    public function testInvokeShouldAddCommentSuccessfully(): void
+    {
+        $user = new User();
+
+        $this->security->expects($this->once())->method('getUser')->willReturn($user);
+        $this->commentService->expects($this->once())->method('addComment')
+            ->with($user, 456, 'src/Service/Test.php', 25, 'Needs refactoring', 'return $value;');
+
+        $result = ($this->tool)(456, 'src/Service/Test.php', 25, 'Needs refactoring', 'return $value;');
+        static::assertSame('Comment added successfully.', $result);
+    }
+
+    public function testInvokeShouldAddCommentWithoutSuggestion(): void
+    {
+        $user = new User();
+
+        $this->security->expects($this->once())->method('getUser')->willReturn($user);
+        $this->commentService->expects($this->once())->method('addComment')
+            ->with($user, 123, 'src/file.php', 10, 'comment message', null);
+
+        $result = ($this->tool)(123, 'src/file.php', 10, 'comment message', null);
+        static::assertSame('Comment added successfully.', $result);
+    }
+}

--- a/tests/Unit/Service/Ai/Mcp/CurrentUserToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/CurrentUserToolTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace DR\Review\Tests\Unit\Service\Ai\Mcp;
 
 use DR\Review\Entity\User\User;
-use DR\Review\Service\Ai\Mcp\CurrentUserTool;
+use DR\Review\Service\Ai\Tool\CurrentUserTool;
 use DR\Review\Service\User\UserEntityProvider;
 use DR\Review\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;

--- a/tests/Unit/Service/Ai/Mcp/GetCodeReviewDiffToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/GetCodeReviewDiffToolTest.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\Ai\Mcp;
+
+use DR\Review\Entity\Git\Diff\DiffFile;
+use DR\Review\Entity\Review\CodeReview;
+use DR\Review\Exception\Ai\CodeReviewNotFoundException;
+use DR\Review\Repository\Mcp\CodeReviewRepository;
+use DR\Review\Service\Ai\Mcp\GetCodeReviewDiffTool;
+use DR\Review\Service\CodeReview\CodeReviewDiffService;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use Throwable;
+
+#[CoversClass(GetCodeReviewDiffTool::class)]
+class GetCodeReviewDiffToolTest extends AbstractTestCase
+{
+    private CodeReviewRepository&MockObject $reviewRepository;
+    private CodeReviewDiffService&MockObject $diffService;
+    private GetCodeReviewDiffTool $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->reviewRepository = $this->createMock(CodeReviewRepository::class);
+        $this->diffService      = $this->createMock(CodeReviewDiffService::class);
+        $this->tool             = new GetCodeReviewDiffTool($this->reviewRepository, $this->diffService);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testInvokeThrowsWhenReviewNotFound(): void
+    {
+        $this->reviewRepository->expects($this->once())->method('find')->with(123)->willReturn(null);
+        $this->diffService->expects($this->never())->method('getDiff');
+
+        $this->expectException(CodeReviewNotFoundException::class);
+        ($this->tool)(123);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testInvokeReturnsNoChangesMessageWhenDiffIsEmpty(): void
+    {
+        $review = new CodeReview();
+
+        $this->reviewRepository->expects($this->once())->method('find')->with(456)->willReturn($review);
+        $this->diffService->expects($this->once())->method('getDiff')->with($review)->willReturn([]);
+
+        $result = ($this->tool)(456);
+        static::assertSame('No changes found in this review.', $result);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testInvokeReturnsConcatenatedRawDiff(): void
+    {
+        $review = new CodeReview();
+
+        $fileA      = new DiffFile();
+        $fileA->raw = 'diff --git a/foo.php';
+
+        $fileB      = new DiffFile();
+        $fileB->raw = 'diff --git a/bar.php';
+
+        $this->reviewRepository->expects($this->once())->method('find')->with(789)->willReturn($review);
+        $this->diffService->expects($this->once())->method('getDiff')->with($review)->willReturn([$fileA, $fileB]);
+
+        $result = ($this->tool)(789);
+        static::assertSame("diff --git a/foo.php\ndiff --git a/bar.php", $result);
+    }
+}

--- a/tests/Unit/Service/Ai/Mcp/GetCodeReviewToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/GetCodeReviewToolTest.php
@@ -11,7 +11,7 @@ use DR\Review\Entity\Review\CodeReview;
 use DR\Review\Model\Mcp\CodeReviewQuery;
 use DR\Review\Model\Mcp\CodeReviewResult;
 use DR\Review\Repository\Mcp\CodeReviewRepository;
-use DR\Review\Service\Ai\Mcp\GetCodeReviewTool;
+use DR\Review\Service\Ai\Tool\GetCodeReviewTool;
 use DR\Review\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/Service/Ai/Mcp/GetCodeReviewsToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/GetCodeReviewsToolTest.php
@@ -12,7 +12,7 @@ use DR\Review\Model\Mcp\CodeReviewQuery;
 use DR\Review\Model\Mcp\CodeReviewResult;
 use DR\Review\Repository\Mcp\CodeReviewRepository;
 use DR\Review\Repository\Review\CodeReviewerRepository;
-use DR\Review\Service\Ai\Mcp\GetCodeReviewsTool;
+use DR\Review\Service\Ai\Tool\GetCodeReviewsTool;
 use DR\Review\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;

--- a/tests/Unit/Service/Ai/Tool/CodeReviewAddCommentToolTest.php
+++ b/tests/Unit/Service/Ai/Tool/CodeReviewAddCommentToolTest.php
@@ -3,83 +3,57 @@ declare(strict_types=1);
 
 namespace DR\Review\Tests\Unit\Service\Ai\Tool;
 
-use DR\Review\Entity\Repository\Repository;
-use DR\Review\Entity\Review\CodeReview;
-use DR\Review\Entity\Review\Comment;
-use DR\Review\Entity\Revision\Revision;
 use DR\Review\Entity\User\User;
-use DR\Review\Exception\Ai\CodeReviewNotFoundException;
-use DR\Review\Repository\Review\CodeReviewRepository;
-use DR\Review\Repository\Review\CommentRepository;
 use DR\Review\Repository\User\UserRepository;
+use DR\Review\Service\Ai\AddCommentService;
 use DR\Review\Service\Ai\Tool\CodeReviewAddCommentTool;
-use DR\Review\Service\CodeReview\CodeReviewRevisionService;
 use DR\Review\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Clock\MockClock;
+use Throwable;
 
 #[CoversClass(CodeReviewAddCommentTool::class)]
 class CodeReviewAddCommentToolTest extends AbstractTestCase
 {
-    private CodeReviewRepository&MockObject      $repository;
-    private UserRepository&MockObject            $userRepository;
-    private CommentRepository&MockObject         $commentRepository;
-    private CodeReviewRevisionService&MockObject $reviewRevisionService;
-    private CodeReviewAddCommentTool             $tool;
+    private UserRepository&MockObject   $userRepository;
+    private AddCommentService&MockObject $commentService;
+    private CodeReviewAddCommentTool    $tool;
 
     public function setUp(): void
     {
         parent::setUp();
-        $this->repository            = $this->createMock(CodeReviewRepository::class);
-        $this->userRepository        = $this->createMock(UserRepository::class);
-        $this->commentRepository     = $this->createMock(CommentRepository::class);
-        $this->reviewRevisionService = $this->createMock(CodeReviewRevisionService::class);
-        $this->tool                  = new CodeReviewAddCommentTool(
-            1,
-            $this->logger,
-            $this->repository,
-            $this->userRepository,
-            $this->commentRepository,
-            $this->reviewRevisionService
-        );
-        $this->tool->setClock(new MockClock());
+        $this->userRepository = $this->createMock(UserRepository::class);
+        $this->commentService = $this->createMock(AddCommentService::class);
+        $this->tool           = new CodeReviewAddCommentTool(1, $this->userRepository, $this->commentService);
     }
 
-    public function testInvokeShouldThrowExceptionWhenReviewNotFound(): void
-    {
-        $this->repository->expects($this->once())->method('find')->with(123)->willReturn(null);
-        $this->userRepository->expects($this->never())->method('find');
-        $this->commentRepository->expects($this->never())->method('save');
-        $this->reviewRevisionService->expects($this->never())->method('getRevisions');
-
-        $this->expectException(CodeReviewNotFoundException::class);
-        ($this->tool)(123, 'src/file.php', 10, 'comment message', null);
-    }
-
+    /**
+     * @throws Throwable
+     */
     public function testInvokeShouldAddCommentSuccessfully(): void
     {
-        $repositoryEntity = new Repository();
-        $revision         = (new Revision())->setRepository($repositoryEntity)->setCommitHash('abc123');
+        $user = new User()->setId(1);
 
-        $review = new CodeReview();
-        $review->getRevisions()->add($revision);
-
-        $user = (new User())->setId(1);
-
-        $this->repository->expects($this->once())->method('find')->with(456)->willReturn($review);
-        $this->reviewRevisionService->expects($this->once())->method('getRevisions')->with($review)->willReturn([$revision]);
         $this->userRepository->expects($this->once())->method('find')->with(1)->willReturn($user);
-        $this->commentRepository->expects($this->once())->method('save')->with(self::isInstanceOf(Comment::class), true);
+        $this->commentService->expects($this->once())->method('addComment')
+            ->with($user, 456, 'src/Service/Test.php', 25, 'This needs refactoring', 'return $value;');
 
         $result = ($this->tool)(456, 'src/Service/Test.php', 25, 'This needs refactoring', 'return $value;');
         static::assertSame('Comment added successfully.', $result);
-        static::assertCount(1, $review->getComments());
+    }
 
-        $comment = $review->getComments()->first();
-        static::assertInstanceOf(Comment::class, $comment);
-        static::assertSame('src/Service/Test.php', $comment->getFilePath());
-        static::assertStringContainsString('This needs refactoring', $comment->getMessage());
-        static::assertStringContainsString('return $value;', $comment->getMessage());
+    /**
+     * @throws Throwable
+     */
+    public function testInvokeShouldAddCommentWithoutSuggestion(): void
+    {
+        $user = new User()->setId(1);
+
+        $this->userRepository->expects($this->once())->method('find')->with(1)->willReturn($user);
+        $this->commentService->expects($this->once())->method('addComment')
+            ->with($user, 123, 'src/file.php', 10, 'comment message', null);
+
+        $result = ($this->tool)(123, 'src/file.php', 10, 'comment message', null);
+        static::assertSame('Comment added successfully.', $result);
     }
 }

--- a/tests/Unit/Service/Ai/Tool/GetCommentsToolTest.php
+++ b/tests/Unit/Service/Ai/Tool/GetCommentsToolTest.php
@@ -1,0 +1,129 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\Ai\Tool;
+
+use DR\Review\Entity\Review\CodeReview;
+use DR\Review\Entity\Review\Comment;
+use DR\Review\Entity\Review\LineReference;
+use DR\Review\Entity\User\User;
+use DR\Review\Repository\Mcp\CodeReviewRepository;
+use DR\Review\Service\Ai\Tool\GetCommentsTool;
+use DR\Review\Tests\AbstractTestCase;
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(GetCommentsTool::class)]
+class GetCommentsToolTest extends AbstractTestCase
+{
+    private CodeReviewRepository&MockObject $reviewRepository;
+    private GetCommentsTool                 $tool;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->reviewRepository = $this->createMock(CodeReviewRepository::class);
+        $this->tool             = new GetCommentsTool($this->reviewRepository);
+    }
+
+    public function testInvokeShouldThrowExceptionWhenReviewNotFound(): void
+    {
+        $this->reviewRepository->expects($this->once())->method('find')->with(123)->willReturn(null);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Code review not found');
+        ($this->tool)(123);
+    }
+
+    public function testInvokeShouldReturnEmptyArrayForReviewWithNoComments(): void
+    {
+        $review = new CodeReview();
+        $this->reviewRepository->expects($this->once())->method('find')->with(456)->willReturn($review);
+
+        $result = ($this->tool)(456);
+        static::assertSame([], $result);
+    }
+
+    public function testInvokeShouldReturnMappedComments(): void
+    {
+        $user = new User()->setId(7)->setName('Jane Doe')->setEmail('jane@example.com');
+
+        $comment = new Comment()
+            ->setId(42)
+            ->setMessage('Needs refactoring')
+            ->setState('open')
+            ->setLineReference(new LineReference(oldPath: 'src/old.php', newPath: 'src/new.php', lineAfter: 25))
+            ->setUser($user)
+            ->setCreateTimestamp(1700000000);
+
+        $review = new CodeReview();
+        $review->getComments()->add($comment);
+
+        $this->reviewRepository->expects($this->once())->method('find')->with(456)->willReturn($review);
+
+        $result = ($this->tool)(456);
+
+        static::assertCount(1, $result);
+        static::assertSame([
+            'commentId' => 42,
+            'message'   => 'Needs refactoring',
+            'state'     => 'open',
+            'file'      => 'src/new.php',
+            'line'      => 25,
+            'author'    => [
+                'userId' => 7,
+                'name'   => 'Jane Doe',
+                'email'  => 'jane@example.com',
+            ],
+            'createdAt' => date('c', 1700000000),
+        ], $result[0]);
+    }
+
+    public function testInvokeShouldFallBackToOldPathWhenNewPathIsNull(): void
+    {
+        $user = new User()->setId(1)->setName('John')->setEmail('john@example.com');
+
+        $comment = new Comment()
+            ->setId(1)
+            ->setMessage('comment')
+            ->setState('open')
+            ->setLineReference(new LineReference(oldPath: 'src/old.php', newPath: null, lineAfter: 10))
+            ->setUser($user)
+            ->setCreateTimestamp(1700000000);
+
+        $review = new CodeReview();
+        $review->getComments()->add($comment);
+
+        $this->reviewRepository->expects($this->once())->method('find')->willReturn($review);
+
+        $result = ($this->tool)(1);
+        static::assertSame('src/old.php', $result[0]['file']);
+    }
+
+    public function testInvokeShouldReturnMultipleComments(): void
+    {
+        $user = new User()->setId(1)->setName('John')->setEmail('john@example.com');
+
+        $comment1 = new Comment()
+            ->setId(1)->setMessage('first')->setState('open')
+            ->setLineReference(new LineReference(newPath: 'a.php', lineAfter: 1))
+            ->setUser($user)->setCreateTimestamp(1000);
+
+        $comment2 = new Comment()
+            ->setId(2)->setMessage('second')->setState('resolved')
+            ->setLineReference(new LineReference(newPath: 'b.php', lineAfter: 5))
+            ->setUser($user)->setCreateTimestamp(2000);
+
+        $review = new CodeReview();
+        $review->getComments()->add($comment1);
+        $review->getComments()->add($comment2);
+
+        $this->reviewRepository->expects($this->once())->method('find')->willReturn($review);
+
+        $result = ($this->tool)(1);
+        static::assertCount(2, $result);
+        static::assertSame(1, $result[0]['commentId']);
+        static::assertSame(2, $result[1]['commentId']);
+    }
+}

--- a/tests/Unit/Service/Ai/Tool/GetCommentsToolTest.php
+++ b/tests/Unit/Service/Ai/Tool/GetCommentsToolTest.php
@@ -7,6 +7,7 @@ use DR\Review\Entity\Review\CodeReview;
 use DR\Review\Entity\Review\Comment;
 use DR\Review\Entity\Review\LineReference;
 use DR\Review\Entity\User\User;
+use DR\Review\Exception\Ai\CodeReviewNotFoundException;
 use DR\Review\Repository\Mcp\CodeReviewRepository;
 use DR\Review\Service\Ai\Tool\GetCommentsTool;
 use DR\Review\Tests\AbstractTestCase;
@@ -31,7 +32,7 @@ class GetCommentsToolTest extends AbstractTestCase
     {
         $this->reviewRepository->expects($this->once())->method('find')->with(123)->willReturn(null);
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(CodeReviewNotFoundException::class);
         $this->expectExceptionMessage('Code review not found');
         ($this->tool)(123);
     }

--- a/tests/Unit/Service/Ai/Tool/GetCommentsToolTest.php
+++ b/tests/Unit/Service/Ai/Tool/GetCommentsToolTest.php
@@ -11,7 +11,6 @@ use DR\Review\Exception\Ai\CodeReviewNotFoundException;
 use DR\Review\Repository\Mcp\CodeReviewRepository;
 use DR\Review\Service\Ai\Tool\GetCommentsTool;
 use DR\Review\Tests\AbstractTestCase;
-use InvalidArgumentException;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -66,19 +65,22 @@ class GetCommentsToolTest extends AbstractTestCase
         $result = ($this->tool)(456);
 
         static::assertCount(1, $result);
-        static::assertSame([
-            'commentId' => 42,
-            'message'   => 'Needs refactoring',
-            'state'     => 'open',
-            'file'      => 'src/new.php',
-            'line'      => 25,
-            'author'    => [
-                'userId' => 7,
-                'name'   => 'Jane Doe',
-                'email'  => 'jane@example.com',
+        static::assertSame(
+            [
+                'commentId' => 42,
+                'message'   => 'Needs refactoring',
+                'state'     => 'open',
+                'file'      => 'src/new.php',
+                'line'      => 25,
+                'author'    => [
+                    'userId' => 7,
+                    'name'   => 'Jane Doe',
+                    'email'  => 'jane@example.com',
+                ],
+                'createdAt' => date('c', 1700000000),
             ],
-            'createdAt' => date('c', 1700000000),
-        ], $result[0]);
+            $result[0]
+        );
     }
 
     public function testInvokeShouldFallBackToOldPathWhenNewPathIsNull(): void

--- a/tests/Unit/Service/CodeReview/CodeReviewDiffServiceTest.php
+++ b/tests/Unit/Service/CodeReview/CodeReviewDiffServiceTest.php
@@ -1,0 +1,87 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\CodeReview;
+
+use DR\Review\Doctrine\Type\CodeReviewType;
+use DR\Review\Entity\Git\Diff\DiffComparePolicy;
+use DR\Review\Entity\Git\Diff\DiffFile;
+use DR\Review\Entity\Repository\Repository;
+use DR\Review\Entity\Review\CodeReview;
+use DR\Review\Entity\Revision\Revision;
+use DR\Review\Service\CodeReview\CodeReviewDiffService;
+use DR\Review\Service\CodeReview\CodeReviewRevisionService;
+use DR\Review\Service\Git\Review\FileDiffOptions;
+use DR\Review\Service\Git\Review\ReviewDiffService\ReviewDiffServiceInterface;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use Throwable;
+
+#[CoversClass(CodeReviewDiffService::class)]
+class CodeReviewDiffServiceTest extends AbstractTestCase
+{
+    private ReviewDiffServiceInterface&MockObject $diffService;
+    private CodeReviewRevisionService&MockObject  $revisionService;
+    private CodeReviewDiffService                 $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->diffService     = $this->createMock(ReviewDiffServiceInterface::class);
+        $this->revisionService = $this->createMock(CodeReviewRevisionService::class);
+        $this->service         = new CodeReviewDiffService($this->diffService, $this->revisionService);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testGetDiffForBranchReview(): void
+    {
+        $diffFile = new DiffFile();
+        $review   = new CodeReview();
+        $review->setType(CodeReviewType::BRANCH);
+        $review->setReferenceId('main');
+
+        $expectedOptions = new FileDiffOptions(5, DiffComparePolicy::IGNORE_EMPTY_LINES, includeRaw: true);
+
+        $this->revisionService->expects($this->never())->method('getRevisions');
+        $this->diffService->expects($this->once())
+            ->method('getDiffForBranch')
+            ->with($review, [], 'main', $expectedOptions)
+            ->willReturn([$diffFile]);
+
+        $result = $this->service->getDiff($review);
+        static::assertSame([$diffFile], $result);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testGetDiffForCommitsReview(): void
+    {
+        $repository = new Repository();
+        $revision   = new Revision();
+        $diffFile   = new DiffFile();
+
+        $review = new CodeReview();
+        $review->setType(CodeReviewType::COMMITS);
+        $review->setRepository($repository);
+
+        $expectedOptions = new FileDiffOptions(5, DiffComparePolicy::IGNORE_EMPTY_LINES, includeRaw: true);
+
+        $this->revisionService->expects($this->once())
+            ->method('getRevisions')
+            ->with($review)
+            ->willReturn([$revision]);
+
+        $this->diffService->expects($this->never())->method('getDiffForBranch');
+        $this->diffService->expects($this->once())
+            ->method('getDiffForRevisions')
+            ->with($repository, [$revision], $expectedOptions)
+            ->willReturn([$diffFile]);
+
+        $result = $this->service->getDiff($review);
+        static::assertSame([$diffFile], $result);
+    }
+}


### PR DESCRIPTION
Adds mcp tools:
- `add_comment`: Add a comment to a code review at a specific file and line number. Optionally include a code suggestion.
- `get_code_review_comments`: Get all comments on the given review. Returns a list of comments with their id, author, content, file path, line number and optionally a code suggestion.
- `get_code_review_diff`: Get the diff for all the changes done in the review. Returns a list of files with their path, name and diff.
- `list_files`: List the files in the given directory path for the specified code review.
- `read_file`: Reads the contents of a file for the given path and review. Returns the file contents as a string. Only searches in the git repository of the specified code review and will not find any dependencies.
