### PR TITLE
Simplify CodeOwnerSectionHeaderParser to return list<string>

### DIFF
--- a/src/Service/CodeOwner/CodeOwnerFileParser.php
+++ b/src/Service/CodeOwner/CodeOwnerFileParser.php
@@ -25,7 +25,6 @@ readonly class CodeOwnerFileParser
     {
         $lines            = Arrays::explode($this->eolCharacter, $content);
         $patterns         = [];
-        $skipSection      = false;
         $sectionDefOwners = [];
 
         foreach ($lines as $line) {
@@ -35,11 +34,7 @@ readonly class CodeOwnerFileParser
             }
 
             if (str_starts_with($line, '[')) {
-                [$skipSection, $sectionDefOwners] = $this->sectionHeaderParser->parse($line);
-                continue;
-            }
-
-            if ($skipSection) {
+                $sectionDefOwners = $this->sectionHeaderParser->parse($line);
                 continue;
             }
 

--- a/src/Service/CodeOwner/CodeOwnerSectionHeaderParser.php
+++ b/src/Service/CodeOwner/CodeOwnerSectionHeaderParser.php
@@ -9,26 +9,21 @@ readonly class CodeOwnerSectionHeaderParser
 {
     /**
      * Parse a section header line like `[Block Name]` or `[Block Name] @owner1 @owner2`.
-     * Returns a tuple of [skipSection, defaultOwners]:
-     * - skipSection=true when the header has no default owners (block should be ignored)
-     * - skipSection=false with the owners list when the header defines default owners
      *
-     * @return array{bool, list<string>}
+     * @return list<string>
      */
     public function parse(string $line): array
     {
         if (preg_match('/^\[[^]]+](?:\s+(?P<owners>[^#]+))?/si', $line, $matches) !== 1) {
-            return [true, []];
+            return [];
         }
 
         $ownersStr = trim($matches['owners'] ?? '');
         if ($ownersStr === '') {
-            return [true, []];
+            return [];
         }
 
-        /** @var list<string> $owners */
-        $owners = Assert::isArray(preg_split('/\s+/', $ownersStr));
-
-        return [false, $owners];
+        /** @phpstan-var list<string> */
+        return Assert::isArray(preg_split('/\s+/', $ownersStr));
     }
 }

--- a/tests/Data/Integration/Service/CodeOwner/CodeOwnerFileParserTest/block-with-header-owners.txt
+++ b/tests/Data/Integration/Service/CodeOwner/CodeOwnerFileParserTest/block-with-header-owners.txt
@@ -1,3 +1,6 @@
+[Header]
+phpunit.xml @role/test
+
 [Block] @role/default @role/secondary # default owners
 src/single.php @role/foo
 src/multi.php @role/bar @role/baz # inline comment

--- a/tests/Integration/Service/CodeOwner/CodeOwnerFileParserTest.php
+++ b/tests/Integration/Service/CodeOwner/CodeOwnerFileParserTest.php
@@ -25,6 +25,7 @@ class CodeOwnerFileParserTest extends AbstractTestCase
     {
         $content = $this->getFileContents('block-with-header-owners.txt');
         $expected = [
+            new OwnerPattern('phpunit.xml', ['@role/test']),
             new OwnerPattern('src/single.php', ['@role/foo']),
             new OwnerPattern('src/multi.php', ['@role/bar', '@role/baz']),
             new OwnerPattern('src/inherited.php', ['@role/default', '@role/secondary']),

--- a/tests/Unit/Service/CodeOwner/CodeOwnerFileParserTest.php
+++ b/tests/Unit/Service/CodeOwner/CodeOwnerFileParserTest.php
@@ -58,7 +58,7 @@ class CodeOwnerFileParserTest extends AbstractTestCase
 
         $this->sectionHeaderParser->expects(static::once())->method('parse')
             ->with('[Block 2] @role/bar')
-            ->willReturn([false, ['@role/bar']]);
+            ->willReturn(['@role/bar']);
 
         $this->lineParser->expects(static::once())->method('parse')
             ->with('readme.md @role/foo', ['@role/bar'])
@@ -67,14 +67,18 @@ class CodeOwnerFileParserTest extends AbstractTestCase
         static::assertEquals([$pattern], $this->parser->parse("[Block 2] @role/bar\nreadme.md @role/foo"));
     }
 
-    public function testParseSkipsLinesInSectionWithNoDefaultOwners(): void
+    public function testParseLineInSectionWithEmptyDefaultOwners(): void
     {
+        $pattern = new OwnerPattern('.gitattributes', ['@role/foo']);
+
         $this->sectionHeaderParser->expects(static::once())->method('parse')
             ->with('[Block 1]')
-            ->willReturn([true, []]);
+            ->willReturn([]);
 
-        $this->lineParser->expects(static::never())->method('parse');
+        $this->lineParser->expects(static::once())->method('parse')
+            ->with('.gitattributes @role/foo', [])
+            ->willReturn($pattern);
 
-        static::assertSame([], $this->parser->parse("[Block 1]\n.gitattributes @role/foo"));
+        static::assertEquals([$pattern], $this->parser->parse("[Block 1]\n.gitattributes @role/foo"));
     }
 }

--- a/tests/Unit/Service/CodeOwner/CodeOwnerSectionHeaderParserTest.php
+++ b/tests/Unit/Service/CodeOwner/CodeOwnerSectionHeaderParserTest.php
@@ -21,28 +21,28 @@ class CodeOwnerSectionHeaderParserTest extends AbstractTestCase
 
     public function testParseInvalidHeader(): void
     {
-        static::assertSame([true, []], $this->parser->parse('[Invalid'));
+        static::assertSame([], $this->parser->parse('[Invalid'));
     }
 
     public function testParseHeaderWithNoOwnersSkipsSection(): void
     {
-        static::assertSame([true, []], $this->parser->parse('[Block 1]'));
+        static::assertSame([], $this->parser->parse('[Block 1]'));
     }
 
     public function testParseHeaderWithSingleOwner(): void
     {
-        static::assertSame([false, ['@role/bar']], $this->parser->parse('[Block 2] @role/bar'));
+        static::assertSame(['@role/bar'], $this->parser->parse('[Block 2] @role/bar'));
     }
 
     public function testParseHeaderWithMultipleOwners(): void
     {
-        static::assertSame([false, ['@role/foo', '@role/bar']], $this->parser->parse('[Block 3] @role/foo @role/bar'));
+        static::assertSame(['@role/foo', '@role/bar'], $this->parser->parse('[Block 3] @role/foo @role/bar'));
     }
 
     #[TestWith(['[Block 1] # comment'])]
     #[TestWith(['[Block 1]# comment'])]
     public function testParseHeaderInlineCommentIsIgnored(string $line): void
     {
-        static::assertSame([true, []], $this->parser->parse($line));
+        static::assertSame([], $this->parser->parse($line));
     }
 }


### PR DESCRIPTION
The `CodeOwnerSectionHeaderParser::parse()` method previously returned a `[bool, list<string>]` tuple where the boolean indicated whether the section should be skipped (i.e., no default owners defined). This was an awkward API that mixed a control-flow concern into a parser return value.

**What changed:**
- `CodeOwnerSectionHeaderParser::parse()` now returns `list<string>` -- just the owners, empty when none are defined.
- `CodeOwnerFileParser` no longer tracks a `$skipSection` flag. Sections with no default owners pass `[]` to `CodeOwnerLineParser`, which already handles that case: if a line has no inline owners and no defaults, it returns `null` and the pattern is simply not added.
- All unit and integration tests updated to match the new API. The integration test fixture gains a `[Header]` block (no default owners) to cover the lines-in-owner-less-section path end-to-end.