### PR TITLE
Fix uninitialized $id access in EditRepositoryFormType

### DIFF
--- a/src/Form/Repository/EditRepositoryFormType.php
+++ b/src/Form/Repository/EditRepositoryFormType.php
@@ -28,7 +28,8 @@ class EditRepositoryFormType extends AbstractType
         /** @var array{repository: Repository|null} $data */
         $data = $options['data'];
 
-        $builder->setAction($this->urlGenerator->generate(RepositoryController::class, ['id' => $data['repository']?->getId()]));
+        $id = $data['repository']?->hasId() === true ? $data['repository']->getId() : null;
+        $builder->setAction($this->urlGenerator->generate(RepositoryController::class, ['id' => $id]));
         $builder->setMethod(Request::METHOD_POST);
         $builder->add('repository', RepositoryType::class);
         $builder->add('save', SubmitType::class, ['label' => 'save']);

--- a/tests/Unit/Form/Repository/EditRepositoryFormTypeTest.php
+++ b/tests/Unit/Form/Repository/EditRepositoryFormTypeTest.php
@@ -28,6 +28,31 @@ class EditRepositoryFormTypeTest extends AbstractTestCase
         $this->type         = new EditRepositoryFormType($this->urlGenerator);
     }
 
+    public function testBuildFormNewRepository(): void
+    {
+        $url        = 'https://123view/add/repository';
+        $repository = new Repository();
+
+        $this->urlGenerator->expects($this->once())
+            ->method('generate')
+            ->with(RepositoryController::class, ['id' => null])
+            ->willReturn($url);
+
+        $builder = $this->createMock(FormBuilderInterface::class);
+        $builder->expects($this->once())->method('setAction')->with($url);
+        $builder->expects($this->once())->method('setMethod')->with('POST');
+        $builder->expects($this->exactly(2))
+            ->method('add')
+            ->with(
+                ...consecutive(
+                    ['repository', RepositoryType::class],
+                    ['save', SubmitType::class, ['label' => 'save']],
+                )
+            )->willReturnSelf();
+
+        $this->type->buildForm($builder, ['data' => ['repository' => $repository]]);
+    }
+
     public function testBuildForm(): void
     {
         $url        = 'https://123view/add/repository';


### PR DESCRIPTION
## Problem

When navigating to the **create new repository** page, a fatal error is thrown:

```
Error: Typed property DR\Review\Entity\Repository\Repository::$id must not be accessed before initialization
  at Repository.php:133
  in EditRepositoryFormType.php:31
```

The `?->` null-safe operator on line 31 only protects against `null`, but a freshly-constructed `Repository` entity is **not** null — its `$id` property is simply uninitialized (Doctrine hasn't persisted it yet).

## Fix

Use the existing `hasId()` guard before calling `getId()`, passing `null` as the route parameter when no id exists yet (matching the intended create-flow):

```php
// before
$builder->setAction($this->urlGenerator->generate(RepositoryController::class, ['id' => $data['repository']?->getId()]));

// after
$id = $data['repository']?->hasId() === true ? $data['repository']->getId() : null;
$builder->setAction($this->urlGenerator->generate(RepositoryController::class, ['id' => $id]));
```

## Tests

Added `testBuildFormNewRepository()` to `EditRepositoryFormTypeTest` covering the new-repository path.