### PR TITLE
Fix uninitialized $id access on new repository entity

### DIFF
--- a/src/Entity/Repository/RepositoryCredential.php
+++ b/src/Entity/Repository/RepositoryCredential.php
@@ -37,6 +37,11 @@ class RepositoryCredential
         return $this;
     }
 
+    public function hasId(): bool
+    {
+        return isset($this->id);
+    }
+
     public function getId(): int
     {
         return $this->id;

--- a/src/Entity/Webhook/Webhook.php
+++ b/src/Entity/Webhook/Webhook.php
@@ -54,6 +54,11 @@ class Webhook
         return $this;
     }
 
+    public function hasId(): bool
+    {
+        return isset($this->id);
+    }
+
     public function getId(): int
     {
         return $this->id;

--- a/src/Form/Repository/Credential/EditCredentialFormType.php
+++ b/src/Form/Repository/Credential/EditCredentialFormType.php
@@ -28,7 +28,9 @@ class EditCredentialFormType extends AbstractType
         /** @var array{credential: RepositoryCredential|null} $data */
         $data = $options['data'];
 
-        $builder->setAction($this->urlGenerator->generate(CredentialController::class, ['id' => $data['credential']?->getId()]));
+        $id  = $data['credential']?->hasId() ? $data['credential']->getId() : null;
+
+        $builder->setAction($this->urlGenerator->generate(CredentialController::class, ['id' => $id]));
         $builder->setMethod(Request::METHOD_POST);
         $builder->add('credential', RepositoryCredentialType::class, ['label' => false]);
         $builder->add('save', SubmitType::class, ['label' => 'save']);

--- a/src/Form/Repository/Credential/EditCredentialFormType.php
+++ b/src/Form/Repository/Credential/EditCredentialFormType.php
@@ -28,7 +28,7 @@ class EditCredentialFormType extends AbstractType
         /** @var array{credential: RepositoryCredential|null} $data */
         $data = $options['data'];
 
-        $id  = $data['credential']?->hasId() ? $data['credential']->getId() : null;
+        $id = $data['credential']?->hasId() === true ? $data['credential']->getId() : null;
 
         $builder->setAction($this->urlGenerator->generate(CredentialController::class, ['id' => $id]));
         $builder->setMethod(Request::METHOD_POST);

--- a/src/Form/Webhook/EditWebhookFormType.php
+++ b/src/Form/Webhook/EditWebhookFormType.php
@@ -25,7 +25,9 @@ class EditWebhookFormType extends AbstractType
         /** @var array{webhook: Webhook|null} $data */
         $data = $options['data'];
 
-        $builder->setAction($this->urlGenerator->generate(WebhookController::class, ['id' => $data['webhook']?->getId()]));
+        $id  = $data['webhook']?->hasId() ? $data['webhook']->getId() : null;
+
+        $builder->setAction($this->urlGenerator->generate(WebhookController::class, ['id' => $id]));
         $builder->setMethod(Request::METHOD_POST);
         $builder->add('webhook', WebhookType::class, ['label' => false]);
         $builder->add('save', SubmitType::class, ['label' => 'save']);

--- a/src/Form/Webhook/EditWebhookFormType.php
+++ b/src/Form/Webhook/EditWebhookFormType.php
@@ -25,7 +25,7 @@ class EditWebhookFormType extends AbstractType
         /** @var array{webhook: Webhook|null} $data */
         $data = $options['data'];
 
-        $id  = $data['webhook']?->hasId() ? $data['webhook']->getId() : null;
+        $id  = $data['webhook']?->hasId() === true ? $data['webhook']->getId() : null;
 
         $builder->setAction($this->urlGenerator->generate(WebhookController::class, ['id' => $id]));
         $builder->setMethod(Request::METHOD_POST);

--- a/templates/app/admin/edit_credential.html.twig
+++ b/templates/app/admin/edit_credential.html.twig
@@ -2,14 +2,14 @@
 
 {% block page_content %}
     <h1 class="mb-4 mt-2">
-        {% if editCredentialModel.credential.id is same as null %}
-            {{ 'add.credential'|trans }}
-        {% else %}
+        {% if editCredentialModel.credential.hasId() %}
             {{ 'edit.credential'|trans }} #{{ editCredentialModel.credential.id }}
+        {% else %}
+            {{ 'add.credential'|trans }}
         {% endif %}
     </h1>
 
-    {% if editCredentialModel.credential.id %}
+    {% if editCredentialModel.credential.hasId() %}
         <div class="alert alert-info" role="alert">
             {{ 'empty.password.will.be.kept'|trans }}
         </div>

--- a/templates/app/admin/edit_repository.html.twig
+++ b/templates/app/admin/edit_repository.html.twig
@@ -29,10 +29,10 @@
         {% set form = editRepositoryModel.form %}
 
         <h1 class="mb-4 mt-2">
-            {% if editRepositoryModel.repository.id is same as null %}
-                {{ 'add.repository'|trans }}
-            {% else %}
+            {% if editRepositoryModel.repository.hasId %}
                 {{ 'edit.repository'|trans }} #{{ editRepositoryModel.repository.id }}
+            {% else %}
+                {{ 'add.repository'|trans }}
             {% endif %}
         </h1>
 

--- a/templates/app/admin/edit_repository.html.twig
+++ b/templates/app/admin/edit_repository.html.twig
@@ -29,7 +29,7 @@
         {% set form = editRepositoryModel.form %}
 
         <h1 class="mb-4 mt-2">
-            {% if editRepositoryModel.repository.hasId %}
+            {% if editRepositoryModel.repository.hasId() %}
                 {{ 'edit.repository'|trans }} #{{ editRepositoryModel.repository.id }}
             {% else %}
                 {{ 'add.repository'|trans }}

--- a/templates/app/admin/edit_webhook.html.twig
+++ b/templates/app/admin/edit_webhook.html.twig
@@ -4,10 +4,10 @@
     {% set form = editWebhookModel.form %}
 
     <h1 class="mb-4 mt-2">
-        {% if editWebhookModel.webhook.id is same as null %}
-            {{ 'add.webhook'|trans }}
-        {% else %}
+        {% if editWebhookModel.webhook.hasId() %}
             {{ 'edit.webhook'|trans }} #{{ editWebhookModel.webhook.id }}
+        {% else %}
+            {{ 'add.webhook'|trans }}
         {% endif %}
     </h1>
 

--- a/tests/Unit/Entity/Repository/RepositoryCredentialTest.php
+++ b/tests/Unit/Entity/Repository/RepositoryCredentialTest.php
@@ -21,6 +21,14 @@ class RepositoryCredentialTest extends AbstractTestCase
         static::assertAccessorPairs(RepositoryCredential::class, $config);
     }
 
+    public function testId(): void
+    {
+        $credential = new RepositoryCredential();
+        static::assertFalse($credential->hasId());
+        $credential->setId(123);
+        static::assertTrue($credential->hasId());
+    }
+
     public function testGetSetCredentials(): void
     {
         $credentials          = new BasicAuthCredential('sherlock', 'holmes');

--- a/tests/Unit/Entity/Webhook/WebhookTest.php
+++ b/tests/Unit/Entity/Webhook/WebhookTest.php
@@ -19,6 +19,14 @@ class WebhookTest extends AbstractTestCase
         static::assertAccessorPairs(Webhook::class, $config);
     }
 
+    public function testId(): void
+    {
+        $webhook = new Webhook();
+        static::assertFalse($webhook->hasId());
+        $webhook->setId(123);
+        static::assertTrue($webhook->hasId());
+    }
+
     public function testSetHeader(): void
     {
         $webhook = new Webhook();


### PR DESCRIPTION
## Problem

When navigating to the "add repository" page, a `RuntimeError` was thrown:

> Typed property `DR\Review\Entity\Repository\Repository::$id` must not be accessed before initialization

This happened because `edit_repository.html.twig` used `editRepositoryModel.repository.id is same as null` to detect a new (unsaved) entity. Accessing `getId()` on a new entity with an uninitialized typed `int $id` property throws a PHP `Error`.

## Fix

Replace the unsafe `id` access with `hasId()`, which uses `isset($this->id)` internally and is safe to call on uninitialized entities.