### PR TITLE
Fix Comment id accessed before initialization on postRemove

### DIFF
--- a/src/EventSubscriber/Dispatch/CommentEventSubscriber.php
+++ b/src/EventSubscriber/Dispatch/CommentEventSubscriber.php
@@ -36,6 +36,7 @@ use Symfony\Contracts\Service\ResetInterface;
 #[AsEntityListener(event: Events::postPersist, method: 'commentAdded', entity: Comment::class)]
 #[AsEntityListener(event: Events::preUpdate, method: 'preCommentUpdated', entity: Comment::class)]
 #[AsEntityListener(event: Events::postUpdate, method: 'commentUpdated', entity: Comment::class)]
+#[AsEntityListener(event: Events::preRemove, method: 'preCommentRemoved', entity: Comment::class)]
 #[AsEntityListener(event: Events::postRemove, method: 'commentRemoved', entity: Comment::class)]
 #[AsEventListener(event: KernelEvents::TERMINATE, method: 'finish')]
 #[AsEventListener(event: ConsoleEvents::TERMINATE, method: 'finish')]
@@ -45,6 +46,8 @@ class CommentEventSubscriber implements ResetInterface
     private array $events = [];
     /** @var array<int, CommentChangeSet> */
     private array $updated = [];
+    /** @var array<int, CommentRemoved> */
+    private array $removed = [];
 
     public function __construct(
         private readonly UserEntityProvider $userEntityProvider,
@@ -106,7 +109,7 @@ class CommentEventSubscriber implements ResetInterface
         }
     }
 
-    public function commentRemoved(Comment $comment): void
+    public function preCommentRemoved(Comment $comment): void
     {
         if ($comment->getType() === CommentTypeEnum::Draft) {
             return;
@@ -117,7 +120,16 @@ class CommentEventSubscriber implements ResetInterface
             return;
         }
 
-        $this->events[] = $this->messageFactory->createRemoved($comment, $user);
+        $this->removed[spl_object_id($comment)] = $this->messageFactory->createRemoved($comment, $user);
+    }
+
+    public function commentRemoved(Comment $comment): void
+    {
+        $event = $this->removed[spl_object_id($comment)] ?? null;
+        unset($this->removed[spl_object_id($comment)]);
+        if ($event !== null) {
+            $this->events[] = $event;
+        }
     }
 
     /**

--- a/src/EventSubscriber/Dispatch/CommentEventSubscriber.php
+++ b/src/EventSubscriber/Dispatch/CommentEventSubscriber.php
@@ -60,6 +60,7 @@ class CommentEventSubscriber implements ResetInterface
     {
         if ($comment->getType() === CommentTypeEnum::Draft) {
             $this->events[] = $this->messageFactory->createDraftAdded($comment, $comment->getUser());
+
             return;
         }
 
@@ -69,13 +70,13 @@ class CommentEventSubscriber implements ResetInterface
     public function preCommentUpdated(Comment $comment, PreUpdateEventArgs $event): void
     {
         /** @var CommentChangeSet $changeSet */
-        $changeSet                                         = $event->getEntityChangeSet();
+        $changeSet                        = $event->getEntityChangeSet();
         $this->updated[$comment->getId()] = $changeSet;
     }
 
     public function commentUpdated(Comment $comment): void
     {
-        $user      = $this->getUser($comment);
+        $user = $this->getUser($comment);
         /** @var CommentChangeSet $changeSet */
         $changeSet = $this->updated[$comment->getId()] ?? null;
         if ($changeSet === null) {
@@ -145,8 +146,10 @@ class CommentEventSubscriber implements ResetInterface
      */
     public function finish(): void
     {
-        $events       = $this->events;
-        $this->events = [];
+        $this->updated = [];
+        $this->removed = [];
+        $events        = $this->events;
+        $this->events  = [];
         foreach ($events as $event) {
             $this->bus->dispatch($event);
         }

--- a/tests/Unit/EventSubscriber/Dispatch/CommentEventSubscriberTest.php
+++ b/tests/Unit/EventSubscriber/Dispatch/CommentEventSubscriberTest.php
@@ -166,6 +166,7 @@ class CommentEventSubscriberTest extends AbstractTestCase
         $this->messageFactory->expects($this->once())->method('createRemoved')->with($comment, $user);
         $this->bus->expects($this->never())->method('dispatch');
 
+        $this->eventSubscriber->preCommentRemoved($comment);
         $this->eventSubscriber->commentRemoved($comment);
     }
 
@@ -177,6 +178,7 @@ class CommentEventSubscriberTest extends AbstractTestCase
         $this->userEntityProvider->expects($this->once())->method('getUser');
         $this->bus->expects($this->never())->method('dispatch');
 
+        $this->eventSubscriber->preCommentRemoved($comment);
         $this->eventSubscriber->commentRemoved($comment);
     }
 
@@ -188,6 +190,7 @@ class CommentEventSubscriberTest extends AbstractTestCase
         $this->messageFactory->expects($this->never())->method('createRemoved');
         $this->bus->expects($this->never())->method('dispatch');
 
+        $this->eventSubscriber->preCommentRemoved($comment);
         $this->eventSubscriber->commentRemoved($comment);
     }
 }


### PR DESCRIPTION
## Problem

When deleting a comment, Doctrine fires the `postRemove` event **after** clearing the entity's identifier. This caused:

```
Error: Typed property DR\Review\Entity\Review\Comment::$id must not be accessed before initialization
```

at `CommentEventMessageFactory.php:77` → `$comment->getId()`.

## Fix

Add a `preRemove` listener (`preCommentRemoved`) that captures the `CommentRemoved` event while the entity ID is still set, keyed by `spl_object_id($comment)`. The existing `postRemove` handler (`commentRemoved`) simply dequeues and enqueues the pre-built event.

This mirrors the existing `preUpdate`/`postUpdate` split pattern already used in `CommentEventSubscriber`.

## Changes

- `src/EventSubscriber/Dispatch/CommentEventSubscriber.php` — add `preRemove` listener; move logic from `postRemove` into it
- `tests/Unit/EventSubscriber/Dispatch/CommentEventSubscriberTest.php` — update tests to call `preCommentRemoved` + `commentRemoved` in sequence