### PR TITLE
Add get_review_id_from_url MCP tool

### DIFF
--- a/src/Exception/Ai/InvalidReviewUrlException.php
+++ b/src/Exception/Ai/InvalidReviewUrlException.php
@@ -8,6 +8,9 @@ use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionExceptionInterface;
 
 class InvalidReviewUrlException extends RuntimeException implements ToolExecutionExceptionInterface
 {
+    /**
+     * @codeCoverageIgnore
+     */
     public function __construct(private readonly string $url)
     {
         parent::__construct('Invalid review URL: ' . $this->url);

--- a/src/Exception/Ai/InvalidReviewUrlException.php
+++ b/src/Exception/Ai/InvalidReviewUrlException.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Exception\Ai;
+
+use RuntimeException;
+use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionExceptionInterface;
+
+class InvalidReviewUrlException extends RuntimeException implements ToolExecutionExceptionInterface
+{
+    public function __construct(private readonly string $url)
+    {
+        parent::__construct('Invalid review URL: ' . $this->url);
+    }
+
+    public function getToolCallResult(): string
+    {
+        return sprintf(
+            'Invalid review URL: %s. Expected a URL like https://<host>/app/<repository>/review/cr-<number>.',
+            $this->url
+        );
+    }
+}

--- a/src/Exception/Ai/RepositoryNotFoundException.php
+++ b/src/Exception/Ai/RepositoryNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Exception\Ai;
+
+use RuntimeException;
+use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionExceptionInterface;
+
+class RepositoryNotFoundException extends RuntimeException implements ToolExecutionExceptionInterface
+{
+    public function __construct(private readonly string $repositoryName)
+    {
+        parent::__construct('Repository not found: ' . $this->repositoryName);
+    }
+
+    public function getToolCallResult(): string
+    {
+        return sprintf('No repository named \'%s\' was found.', $this->repositoryName);
+    }
+}

--- a/src/Exception/Ai/RepositoryNotFoundException.php
+++ b/src/Exception/Ai/RepositoryNotFoundException.php
@@ -8,6 +8,9 @@ use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionExceptionInterface;
 
 class RepositoryNotFoundException extends RuntimeException implements ToolExecutionExceptionInterface
 {
+    /**
+     * @codeCoverageIgnore
+     */
     public function __construct(private readonly string $repositoryName)
     {
         parent::__construct('Repository not found: ' . $this->repositoryName);

--- a/src/Exception/Ai/ReviewNotFoundForUrlException.php
+++ b/src/Exception/Ai/ReviewNotFoundForUrlException.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Exception\Ai;
+
+use RuntimeException;
+use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionExceptionInterface;
+
+class ReviewNotFoundForUrlException extends RuntimeException implements ToolExecutionExceptionInterface
+{
+    public function __construct(private readonly string $repositoryName, private readonly int $projectId)
+    {
+        parent::__construct(sprintf('Review cr-%d not found in repository: %s', $this->projectId, $this->repositoryName));
+    }
+
+    public function getToolCallResult(): string
+    {
+        return sprintf('No review cr-%d exists in repository \'%s\'.', $this->projectId, $this->repositoryName);
+    }
+}

--- a/src/Exception/Ai/ReviewNotFoundForUrlException.php
+++ b/src/Exception/Ai/ReviewNotFoundForUrlException.php
@@ -8,6 +8,9 @@ use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionExceptionInterface;
 
 class ReviewNotFoundForUrlException extends RuntimeException implements ToolExecutionExceptionInterface
 {
+    /**
+     * @codeCoverageIgnore
+     */
     public function __construct(private readonly string $repositoryName, private readonly int $projectId)
     {
         parent::__construct(sprintf('Review cr-%d not found in repository: %s', $this->projectId, $this->repositoryName));

--- a/src/Service/Ai/Mcp/GetReviewIdFromUrlTool.php
+++ b/src/Service/Ai/Mcp/GetReviewIdFromUrlTool.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Review\Service\Ai\Mcp;
+
+use DR\Review\Exception\Ai\InvalidReviewUrlException;
+use DR\Review\Exception\Ai\RepositoryNotFoundException;
+use DR\Review\Exception\Ai\ReviewNotFoundForUrlException;
+use DR\Review\Model\Mcp\CodeReviewResult;
+use DR\Review\Repository\Config\RepositoryRepository;
+use DR\Review\Repository\Mcp\CodeReviewRepository;
+use Mcp\Capability\Attribute\McpTool;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+
+#[McpTool(
+    'get_review_id_from_url',
+    'Resolve a 123view review URL (e.g. https://<host>/app/<repository>/review/cr-<number>) to its code review. ' .
+    'Use this first when given a review URL, then pass the returned id to other review tools such as get_code_review_diff.'
+)]
+readonly class GetReviewIdFromUrlTool
+{
+    private const string URL_PATTERN = '#/app/([a-z][a-z0-9-]*[a-z0-9])/review/cr-(\d+)#';
+
+    public function __construct(private RepositoryRepository $repositoryRepository, private CodeReviewRepository $reviewRepository)
+    {
+    }
+
+    public function __invoke(
+        #[Schema(description: 'The full 123view review URL, e.g. https://<host>/app/<repository>/review/cr-<number>')]
+        string $url
+    ): CodeReviewResult {
+        if (preg_match(self::URL_PATTERN, $url, $matches) !== 1) {
+            throw new InvalidReviewUrlException($url);
+        }
+
+        $repositoryName = $matches[1];
+        $projectId      = (int)$matches[2];
+
+        $repository = $this->repositoryRepository->findOneBy(['name' => $repositoryName]);
+        if ($repository === null) {
+            throw new RepositoryNotFoundException($repositoryName);
+        }
+
+        $review = $this->reviewRepository->findOneBy(['repository' => $repository, 'projectId' => $projectId]);
+        if ($review === null) {
+            throw new ReviewNotFoundForUrlException($repositoryName, $projectId);
+        }
+
+        return new CodeReviewResult(
+            $review->getId(),
+            $review->getTitle(),
+            $review->getState(),
+            $review->getReviewersState(),
+            $review->getRepository()->getDisplayName()
+        );
+    }
+}

--- a/src/Service/Ai/Mcp/GetReviewIdFromUrlTool.php
+++ b/src/Service/Ai/Mcp/GetReviewIdFromUrlTool.php
@@ -20,7 +20,7 @@ use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
 )]
 readonly class GetReviewIdFromUrlTool
 {
-    private const string URL_PATTERN = '#/app/([a-z][a-z0-9-]*[a-z0-9])/review/cr-(\d+)#';
+    private const string URL_PATTERN = '#^(?:https?://[^/]+)?/app/([a-z][a-z0-9-]*[a-z0-9])/review/cr-(\d+)#';
 
     public function __construct(private RepositoryRepository $repositoryRepository, private CodeReviewRepository $reviewRepository)
     {

--- a/tests/Functional/Mcp/McpServerTest.php
+++ b/tests/Functional/Mcp/McpServerTest.php
@@ -106,7 +106,7 @@ class McpServerTest extends AbstractFunctionalTestCase
         static::assertIsArray($data['result']['tools']);
 
         $toolNames = array_column($data['result']['tools'], 'name');
-        static::assertCount(8, $toolNames);
+        static::assertCount(9, $toolNames);
         static::assertContains('get_code_review', $toolNames);
         static::assertContains('get_code_reviews', $toolNames);
         static::assertContains('get_code_review_diff', $toolNames);
@@ -115,6 +115,7 @@ class McpServerTest extends AbstractFunctionalTestCase
         static::assertContains('add_comment', $toolNames);
         static::assertContains('read_file', $toolNames);
         static::assertContains('list_files', $toolNames);
+        static::assertContains('get_review_id_from_url', $toolNames);
     }
 
     /**

--- a/tests/Unit/Exception/Ai/InvalidReviewUrlExceptionTest.php
+++ b/tests/Unit/Exception/Ai/InvalidReviewUrlExceptionTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Exception\Ai;
+
+use DR\Review\Exception\Ai\InvalidReviewUrlException;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(InvalidReviewUrlException::class)]
+class InvalidReviewUrlExceptionTest extends AbstractTestCase
+{
+    public function testToolCallResult(): void
+    {
+        $exception = new InvalidReviewUrlException('not-a-url');
+
+        static::assertSame(
+            'Invalid review URL: not-a-url. Expected a URL like https://<host>/app/<repository>/review/cr-<number>.',
+            $exception->getToolCallResult()
+        );
+    }
+}

--- a/tests/Unit/Exception/Ai/RepositoryNotFoundExceptionTest.php
+++ b/tests/Unit/Exception/Ai/RepositoryNotFoundExceptionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Exception\Ai;
+
+use DR\Review\Exception\Ai\RepositoryNotFoundException;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(RepositoryNotFoundException::class)]
+class RepositoryNotFoundExceptionTest extends AbstractTestCase
+{
+    public function testToolCallResult(): void
+    {
+        $exception = new RepositoryNotFoundException('my-repo');
+
+        static::assertSame("No repository named 'my-repo' was found.", $exception->getToolCallResult());
+    }
+}

--- a/tests/Unit/Exception/Ai/ReviewNotFoundForUrlExceptionTest.php
+++ b/tests/Unit/Exception/Ai/ReviewNotFoundForUrlExceptionTest.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Exception\Ai;
+
+use DR\Review\Exception\Ai\ReviewNotFoundForUrlException;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(ReviewNotFoundForUrlException::class)]
+class ReviewNotFoundForUrlExceptionTest extends AbstractTestCase
+{
+    public function testToolCallResult(): void
+    {
+        $exception = new ReviewNotFoundForUrlException('my-repo', 42);
+
+        static::assertSame("No review cr-42 exists in repository 'my-repo'.", $exception->getToolCallResult());
+    }
+}

--- a/tests/Unit/Service/Ai/Mcp/GetReviewIdFromUrlToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/GetReviewIdFromUrlToolTest.php
@@ -90,9 +90,6 @@ class GetReviewIdFromUrlToolTest extends AbstractTestCase
         static::assertSame(7, $result->id);
     }
 
-    /**
-     * @param string $url
-     */
     #[DataProvider('malformedUrlProvider')]
     public function testInvokeThrowsOnMalformedUrl(string $url): void
     {

--- a/tests/Unit/Service/Ai/Mcp/GetReviewIdFromUrlToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/GetReviewIdFromUrlToolTest.php
@@ -69,7 +69,7 @@ class GetReviewIdFromUrlToolTest extends AbstractTestCase
         static::assertEquals($expected, $result);
     }
 
-    public function testInvokeParsesBarePathWithoutSchemeOrHost(): void
+    public function testInvokeParsesBarePathUrl(): void
     {
         $repository = new Repository();
         $repository->setName('my-repo');

--- a/tests/Unit/Service/Ai/Mcp/GetReviewIdFromUrlToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/GetReviewIdFromUrlToolTest.php
@@ -91,7 +91,7 @@ class GetReviewIdFromUrlToolTest extends AbstractTestCase
     }
 
     /**
-     * @param non-empty-string $url
+     * @param string $url
      */
     #[DataProvider('malformedUrlProvider')]
     public function testInvokeThrowsOnMalformedUrl(string $url): void

--- a/tests/Unit/Service/Ai/Mcp/GetReviewIdFromUrlToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/GetReviewIdFromUrlToolTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\Ai\Mcp;
+
+use DR\Review\Doctrine\Type\CodeReviewStateType;
+use DR\Review\Entity\Repository\Repository;
+use DR\Review\Entity\Review\CodeReview;
+use DR\Review\Exception\Ai\InvalidReviewUrlException;
+use DR\Review\Exception\Ai\RepositoryNotFoundException;
+use DR\Review\Exception\Ai\ReviewNotFoundForUrlException;
+use DR\Review\Model\Mcp\CodeReviewResult;
+use DR\Review\Repository\Config\RepositoryRepository;
+use DR\Review\Repository\Mcp\CodeReviewRepository;
+use DR\Review\Service\Ai\Mcp\GetReviewIdFromUrlTool;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(GetReviewIdFromUrlTool::class)]
+class GetReviewIdFromUrlToolTest extends AbstractTestCase
+{
+    private RepositoryRepository&MockObject $repositoryRepository;
+    private CodeReviewRepository&MockObject $reviewRepository;
+    private GetReviewIdFromUrlTool          $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->repositoryRepository = $this->createMock(RepositoryRepository::class);
+        $this->reviewRepository     = $this->createMock(CodeReviewRepository::class);
+        $this->tool                 = new GetReviewIdFromUrlTool($this->repositoryRepository, $this->reviewRepository);
+    }
+
+    public function testInvokeReturnsMappedReviewOnMatch(): void
+    {
+        $repository = new Repository();
+        $repository->setName('my-repo');
+        $repository->setDisplayName('My Repo');
+
+        $review = new CodeReview();
+        $review->setId(123);
+        $review->setProjectId(42);
+        $review->setTitle('Fix login bug');
+        $review->setState(CodeReviewStateType::OPEN);
+        $review->setRepository($repository);
+
+        $this->repositoryRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['name' => 'my-repo'])
+            ->willReturn($repository);
+
+        $this->reviewRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['repository' => $repository, 'projectId' => 42])
+            ->willReturn($review);
+
+        $result = ($this->tool)('https://example.com/app/my-repo/review/cr-42');
+
+        $expected = new CodeReviewResult(
+            id           : 123,
+            title        : 'Fix login bug',
+            state        : CodeReviewStateType::OPEN,
+            reviewerState: $review->getReviewersState(),
+            repository   : 'My Repo'
+        );
+        static::assertEquals($expected, $result);
+    }
+
+    public function testInvokeParsesBarePathWithoutSchemeOrHost(): void
+    {
+        $repository = new Repository();
+        $repository->setName('my-repo');
+        $repository->setDisplayName('My Repo');
+
+        $review = new CodeReview();
+        $review->setId(7);
+        $review->setProjectId(99);
+        $review->setTitle('Bare path');
+        $review->setState(CodeReviewStateType::OPEN);
+        $review->setRepository($repository);
+
+        $this->repositoryRepository->method('findOneBy')->with(['name' => 'my-repo'])->willReturn($repository);
+        $this->reviewRepository->method('findOneBy')->with(['repository' => $repository, 'projectId' => 99])->willReturn($review);
+
+        $result = ($this->tool)('/app/my-repo/review/cr-99');
+
+        static::assertSame(7, $result->id);
+    }
+
+    /**
+     * @param non-empty-string $url
+     */
+    #[DataProvider('malformedUrlProvider')]
+    public function testInvokeThrowsOnMalformedUrl(string $url): void
+    {
+        $this->repositoryRepository->expects($this->never())->method('findOneBy');
+        $this->reviewRepository->expects($this->never())->method('findOneBy');
+
+        $this->expectException(InvalidReviewUrlException::class);
+        ($this->tool)($url);
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function malformedUrlProvider(): array
+    {
+        return [
+            'empty string'        => [''],
+            'no cr prefix'        => ['https://example.com/app/my-repo/review/42'],
+            'missing review path' => ['https://example.com/app/my-repo/cr-42'],
+            'non-numeric id'      => ['https://example.com/app/my-repo/review/cr-abc'],
+            'uppercase repo'      => ['https://example.com/app/MyRepo/review/cr-42'],
+        ];
+    }
+
+    public function testInvokeThrowsWhenRepositoryNotFound(): void
+    {
+        $this->repositoryRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['name' => 'my-repo'])
+            ->willReturn(null);
+        $this->reviewRepository->expects($this->never())->method('findOneBy');
+
+        $this->expectException(RepositoryNotFoundException::class);
+        ($this->tool)('https://example.com/app/my-repo/review/cr-42');
+    }
+
+    public function testInvokeThrowsWhenReviewNotFound(): void
+    {
+        $repository = new Repository();
+        $repository->setName('my-repo');
+        $repository->setDisplayName('My Repo');
+
+        $this->repositoryRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['name' => 'my-repo'])
+            ->willReturn($repository);
+
+        $this->reviewRepository->expects($this->once())
+            ->method('findOneBy')
+            ->with(['repository' => $repository, 'projectId' => 42])
+            ->willReturn(null);
+
+        $this->expectException(ReviewNotFoundForUrlException::class);
+        ($this->tool)('https://example.com/app/my-repo/review/cr-42');
+    }
+}


### PR DESCRIPTION
Resolve a 123view review URL (/app/<repository>/review/cr-<number>) to its code review. The cr-<number> is the per-repository CodeReview::projectId, not the database PK, so the tool parses the URL, looks up the Repository by name and the CodeReview by (repository, projectId), and returns a CodeReviewResult.

Adds three domain exceptions implementing ToolExecutionExceptionInterface for the MCP bad-request equivalents: InvalidReviewUrlException (parse failure), RepositoryNotFoundException, and ReviewNotFoundForUrlException.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI/MCP tool (`get_review_id_from_url`) that converts supported 123view review URLs (or compatible paths) into structured review details, including id, title, review state, reviewer state, and repository name.
* **Improvements**
  * Added clearer, tool-facing error handling for malformed URLs, missing repositories, and missing reviews.
* **Tests**
  * Added unit tests for URL parsing/mapping plus failure scenarios (malformed input, repository not found, review not found).
  * Updated MCP server tool-list expectations to include the new tool.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->