### PR TITLE
Add correct LineReference

### DIFF
--- a/src/Service/Ai/AddCommentService.php
+++ b/src/Service/Ai/AddCommentService.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 namespace DR\Review\Service\Ai;
 
 use DR\Review\Entity\Review\Comment;
-use DR\Review\Entity\Review\LineReference;
 use DR\Review\Entity\Review\NotificationStatus;
 use DR\Review\Entity\Revision\Revision;
 use DR\Review\Entity\User\User;
@@ -12,6 +11,7 @@ use DR\Review\Exception\Ai\CodeReviewNotFoundException;
 use DR\Review\Repository\Review\CodeReviewRepository;
 use DR\Review\Repository\Review\CommentRepository;
 use DR\Review\Service\CodeReview\CodeReviewRevisionService;
+use DR\Review\Service\CodeReview\LineReferenceFactory;
 use DR\Utils\Arrays;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Clock\ClockAwareTrait;
@@ -24,7 +24,8 @@ class AddCommentService
         private ?LoggerInterface $aiLogger,
         private readonly CodeReviewRepository $repository,
         private readonly CommentRepository $commentRepository,
-        private readonly CodeReviewRevisionService $reviewRevisionService
+        private readonly CodeReviewRevisionService $reviewRevisionService,
+        private readonly LineReferenceFactory $lineReferenceFactory
     ) {
     }
 
@@ -53,7 +54,7 @@ class AddCommentService
         $comment = new Comment();
         $comment->setFilePath($filepath);
         $comment->setTag(null);
-        $comment->setLineReference(new LineReference($filepath, $filepath, $lineNumber, lineAfter: $lineNumber, headSha: $revision->getCommitHash()));
+        $comment->setLineReference($this->lineReferenceFactory->createFromReview($review, $filepath, $lineNumber, $revision->getCommitHash()));
         $comment->setReview($review);
         $comment->setMessage($message);
         $comment->setUser($user);

--- a/src/Service/CodeReview/LineReferenceFactory.php
+++ b/src/Service/CodeReview/LineReferenceFactory.php
@@ -55,7 +55,9 @@ readonly class LineReferenceFactory
                         DiffLine::STATE_ADDED                            => LineReferenceStateEnum::Added,
                         DiffLine::STATE_CHANGED, DiffLine::STATE_INLINED => LineReferenceStateEnum::Modified,
                         DiffLine::STATE_UNCHANGED                        => LineReferenceStateEnum::Unmodified,
+                        // @codeCoverageIgnoreStart
                         default                                          => LineReferenceStateEnum::Unknown,
+                        // @codeCoverageIgnoreEnd
                     };
                     break 2;
                 }

--- a/src/Service/CodeReview/LineReferenceFactory.php
+++ b/src/Service/CodeReview/LineReferenceFactory.php
@@ -33,21 +33,25 @@ readonly class LineReferenceFactory
 
     public function createFromDiffFile(DiffFile $diffFile, int $lineNumber, string $headSha): LineReference
     {
-        $anchorLine = $lineNumber;
-        $offset     = 0;
-        $state      = LineReferenceStateEnum::Unknown;
+        $anchorLine    = $lineNumber;
+        $offset        = 0;
+        $state         = LineReferenceStateEnum::Unknown;
+        $currentAnchor = $lineNumber;
+        $currentOffset = 0;
 
         foreach ($diffFile->getBlocks() as $block) {
             foreach ($block->lines as $diffLine) {
                 if ($diffLine->lineNumberBefore !== null) {
-                    $anchorLine = $diffLine->lineNumberBefore;
-                    $offset     = 0;
+                    $currentAnchor = $diffLine->lineNumberBefore;
+                    $currentOffset = 0;
                 } else {
-                    $offset++;
+                    $currentOffset++;
                 }
 
                 if ($diffLine->lineNumberAfter === $lineNumber) {
-                    $state = match ($diffLine->state) {
+                    $anchorLine = $currentAnchor;
+                    $offset     = $currentOffset;
+                    $state      = match ($diffLine->state) {
                         DiffLine::STATE_ADDED                            => LineReferenceStateEnum::Added,
                         DiffLine::STATE_CHANGED, DiffLine::STATE_INLINED => LineReferenceStateEnum::Modified,
                         DiffLine::STATE_UNCHANGED                        => LineReferenceStateEnum::Unmodified,

--- a/src/Service/CodeReview/LineReferenceFactory.php
+++ b/src/Service/CodeReview/LineReferenceFactory.php
@@ -1,0 +1,63 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Service\CodeReview;
+
+use DR\Review\Entity\Git\Diff\DiffFile;
+use DR\Review\Entity\Git\Diff\DiffLine;
+use DR\Review\Entity\Review\CodeReview;
+use DR\Review\Entity\Review\LineReference;
+use DR\Review\Entity\Review\LineReferenceStateEnum;
+use Throwable;
+
+readonly class LineReferenceFactory
+{
+    public function __construct(private CodeReviewDiffService $diffService, private DiffFinder $diffFinder)
+    {
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function createFromReview(CodeReview $review, string $filepath, int $lineNumber, string $headSha): LineReference
+    {
+        $diffFiles = $this->diffService->getDiff($review);
+        $diffFile  = $this->diffFinder->findFileByPath($diffFiles, $filepath);
+
+        if ($diffFile === null) {
+            return new LineReference($filepath, $filepath, $lineNumber, 0, $lineNumber, $headSha);
+        }
+
+        return $this->createFromDiffFile($diffFile, $lineNumber, $headSha);
+    }
+
+    public function createFromDiffFile(DiffFile $diffFile, int $lineNumber, string $headSha): LineReference
+    {
+        $anchorLine = $lineNumber;
+        $offset     = 0;
+        $state      = LineReferenceStateEnum::Unknown;
+
+        foreach ($diffFile->getBlocks() as $block) {
+            foreach ($block->lines as $diffLine) {
+                if ($diffLine->lineNumberBefore !== null) {
+                    $anchorLine = $diffLine->lineNumberBefore;
+                    $offset     = 0;
+                } else {
+                    $offset++;
+                }
+
+                if ($diffLine->lineNumberAfter === $lineNumber) {
+                    $state = match ($diffLine->state) {
+                        DiffLine::STATE_ADDED                            => LineReferenceStateEnum::Added,
+                        DiffLine::STATE_CHANGED, DiffLine::STATE_INLINED => LineReferenceStateEnum::Modified,
+                        DiffLine::STATE_UNCHANGED                        => LineReferenceStateEnum::Unmodified,
+                        default                                          => LineReferenceStateEnum::Unknown,
+                    };
+                    break 2;
+                }
+            }
+        }
+
+        return new LineReference($diffFile->filePathBefore, $diffFile->filePathAfter, $anchorLine, $offset, $lineNumber, $headSha, $state);
+    }
+}

--- a/tests/Unit/Service/Ai/AddCommentServiceTest.php
+++ b/tests/Unit/Service/Ai/AddCommentServiceTest.php
@@ -6,6 +6,8 @@ namespace DR\Review\Tests\Unit\Service\Ai;
 use DR\Review\Entity\Repository\Repository;
 use DR\Review\Entity\Review\CodeReview;
 use DR\Review\Entity\Review\Comment;
+use DR\Review\Entity\Review\LineReference;
+use DR\Review\Entity\Review\LineReferenceStateEnum;
 use DR\Review\Entity\Revision\Revision;
 use DR\Review\Entity\User\User;
 use DR\Review\Exception\Ai\CodeReviewNotFoundException;
@@ -13,6 +15,7 @@ use DR\Review\Repository\Review\CodeReviewRepository;
 use DR\Review\Repository\Review\CommentRepository;
 use DR\Review\Service\Ai\AddCommentService;
 use DR\Review\Service\CodeReview\CodeReviewRevisionService;
+use DR\Review\Service\CodeReview\LineReferenceFactory;
 use DR\Review\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -24,6 +27,7 @@ class AddCommentServiceTest extends AbstractTestCase
     private CodeReviewRepository&MockObject      $repository;
     private CommentRepository&MockObject         $commentRepository;
     private CodeReviewRevisionService&MockObject $reviewRevisionService;
+    private LineReferenceFactory&MockObject      $lineReferenceFactory;
     private AddCommentService                    $service;
 
     public function setUp(): void
@@ -32,11 +36,14 @@ class AddCommentServiceTest extends AbstractTestCase
         $this->repository            = $this->createMock(CodeReviewRepository::class);
         $this->commentRepository     = $this->createMock(CommentRepository::class);
         $this->reviewRevisionService = $this->createMock(CodeReviewRevisionService::class);
+        $this->lineReferenceFactory  = $this->createMock(LineReferenceFactory::class);
+        $this->lineReferenceFactory->method('createFromReview')->willReturn(new LineReference());
         $this->service               = new AddCommentService(
             $this->logger,
             $this->repository,
             $this->commentRepository,
-            $this->reviewRevisionService
+            $this->reviewRevisionService,
+            $this->lineReferenceFactory
         );
         $this->service->setClock(new MockClock('2024-01-01T12:00:00+00:00'));
     }
@@ -57,9 +64,14 @@ class AddCommentServiceTest extends AbstractTestCase
         $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
         $review           = new CodeReview()->setId(456);
         $user             = new User()->setId(1);
+        $lineReference    = new LineReference('src/Service/Test.php', 'src/Service/Test.php', 23, 2, 25, 'abc123', LineReferenceStateEnum::Added);
 
         $this->repository->expects($this->once())->method('find')->with(456)->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->with($review)->willReturn([$revision]);
+        $this->lineReferenceFactory->expects($this->once())
+            ->method('createFromReview')
+            ->with($review, 'src/Service/Test.php', 25, 'abc123')
+            ->willReturn($lineReference);
         $this->commentRepository->expects($this->once())->method('save')->with(self::isInstanceOf(Comment::class), true);
 
         $this->service->addComment($user, 456, 'src/Service/Test.php', 25, 'Needs refactoring', null);
@@ -71,13 +83,7 @@ class AddCommentServiceTest extends AbstractTestCase
         static::assertSame('Needs refactoring', $comment->getMessage());
         static::assertSame($user, $comment->getUser());
         static::assertSame($review, $comment->getReview());
-
-        $ref = $comment->getLineReference();
-        static::assertSame('src/Service/Test.php', $ref->oldPath);
-        static::assertSame('src/Service/Test.php', $ref->newPath);
-        static::assertSame(25, $ref->line);
-        static::assertSame(25, $ref->lineAfter);
-        static::assertSame('abc123', $ref->headSha);
+        static::assertSame($lineReference, $comment->getLineReference());
     }
 
     public function testAddCommentShouldAppendCodeSuggestion(): void
@@ -155,7 +161,7 @@ class AddCommentServiceTest extends AbstractTestCase
         $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
         $review           = new CodeReview();
 
-        $service = new AddCommentService(null, $this->repository, $this->commentRepository, $this->reviewRevisionService);
+        $service = new AddCommentService(null, $this->repository, $this->commentRepository, $this->reviewRevisionService, $this->lineReferenceFactory);
         $service->setClock(new MockClock('2024-01-01T12:00:00+00:00'));
 
         $this->repository->expects($this->once())->method('find')->willReturn($review);

--- a/tests/Unit/Service/Ai/AddCommentServiceTest.php
+++ b/tests/Unit/Service/Ai/AddCommentServiceTest.php
@@ -37,7 +37,6 @@ class AddCommentServiceTest extends AbstractTestCase
         $this->commentRepository     = $this->createMock(CommentRepository::class);
         $this->reviewRevisionService = $this->createMock(CodeReviewRevisionService::class);
         $this->lineReferenceFactory  = $this->createMock(LineReferenceFactory::class);
-        $this->lineReferenceFactory->method('createFromReview')->willReturn(new LineReference());
         $this->service               = new AddCommentService(
             $this->logger,
             $this->repository,
@@ -92,6 +91,7 @@ class AddCommentServiceTest extends AbstractTestCase
         $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('def456');
         $review           = new CodeReview()->setId(1);
 
+        $this->lineReferenceFactory->expects($this->never())->method(static::anything());
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
         $this->commentRepository->expects($this->once())->method('save');
@@ -109,6 +109,7 @@ class AddCommentServiceTest extends AbstractTestCase
         $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
         $review           = new CodeReview()->setId(1);
 
+        $this->lineReferenceFactory->expects($this->never())->method(static::anything());
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
         $this->commentRepository->expects($this->once())->method('save');
@@ -126,6 +127,7 @@ class AddCommentServiceTest extends AbstractTestCase
         $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
         $review           = new CodeReview()->setId(1);
 
+        $this->lineReferenceFactory->expects($this->never())->method(static::anything());
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
         $this->commentRepository->expects($this->once())->method('save');
@@ -143,6 +145,7 @@ class AddCommentServiceTest extends AbstractTestCase
         $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
         $review           = new CodeReview()->setId(1);
 
+        $this->lineReferenceFactory->expects($this->never())->method(static::anything());
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
         $this->commentRepository->expects($this->once())->method('save');
@@ -164,6 +167,7 @@ class AddCommentServiceTest extends AbstractTestCase
         $service = new AddCommentService(null, $this->repository, $this->commentRepository, $this->reviewRevisionService, $this->lineReferenceFactory);
         $service->setClock(new MockClock('2024-01-01T12:00:00+00:00'));
 
+        $this->lineReferenceFactory->expects($this->never())->method(static::anything());
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
         $this->commentRepository->expects($this->once())->method('save');

--- a/tests/Unit/Service/Ai/AddCommentServiceTest.php
+++ b/tests/Unit/Service/Ai/AddCommentServiceTest.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace DR\Review\Tests\Unit\Service\Ai;
 
+use DR\PHPUnitExtensions\Symfony\ClockTestTrait;
 use DR\Review\Entity\Repository\Repository;
 use DR\Review\Entity\Review\CodeReview;
 use DR\Review\Entity\Review\Comment;
@@ -19,11 +20,12 @@ use DR\Review\Service\CodeReview\LineReferenceFactory;
 use DR\Review\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
-use Symfony\Component\Clock\MockClock;
 
 #[CoversClass(AddCommentService::class)]
 class AddCommentServiceTest extends AbstractTestCase
 {
+    use ClockTestTrait;
+
     private CodeReviewRepository&MockObject      $repository;
     private CommentRepository&MockObject         $commentRepository;
     private CodeReviewRevisionService&MockObject $reviewRevisionService;
@@ -44,11 +46,11 @@ class AddCommentServiceTest extends AbstractTestCase
             $this->reviewRevisionService,
             $this->lineReferenceFactory
         );
-        $this->service->setClock(new MockClock('2024-01-01T12:00:00+00:00'));
     }
 
     public function testAddCommentShouldThrowExceptionWhenReviewNotFound(): void
     {
+        $this->lineReferenceFactory->expects($this->never())->method(static::anything());
         $this->repository->expects($this->once())->method('find')->with(123)->willReturn(null);
         $this->commentRepository->expects($this->never())->method('save');
         $this->reviewRevisionService->expects($this->never())->method('getRevisions');
@@ -82,7 +84,7 @@ class AddCommentServiceTest extends AbstractTestCase
         static::assertSame('Needs refactoring', $comment->getMessage());
         static::assertSame($user, $comment->getUser());
         static::assertSame($review, $comment->getReview());
-        static::assertSame($lineReference, $comment->getLineReference());
+        static::assertEquals($lineReference, $comment->getLineReference());
     }
 
     public function testAddCommentShouldAppendCodeSuggestion(): void
@@ -91,7 +93,7 @@ class AddCommentServiceTest extends AbstractTestCase
         $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('def456');
         $review           = new CodeReview()->setId(1);
 
-        $this->lineReferenceFactory->expects($this->never())->method(static::anything());
+        $this->lineReferenceFactory->expects($this->once())->method('createFromReview')->willReturn(new LineReference());
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
         $this->commentRepository->expects($this->once())->method('save');
@@ -109,7 +111,7 @@ class AddCommentServiceTest extends AbstractTestCase
         $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
         $review           = new CodeReview()->setId(1);
 
-        $this->lineReferenceFactory->expects($this->never())->method(static::anything());
+        $this->lineReferenceFactory->expects($this->once())->method('createFromReview')->willReturn(new LineReference());
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
         $this->commentRepository->expects($this->once())->method('save');
@@ -127,7 +129,7 @@ class AddCommentServiceTest extends AbstractTestCase
         $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
         $review           = new CodeReview()->setId(1);
 
-        $this->lineReferenceFactory->expects($this->never())->method(static::anything());
+        $this->lineReferenceFactory->expects($this->once())->method('createFromReview')->willReturn(new LineReference());
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
         $this->commentRepository->expects($this->once())->method('save');
@@ -145,7 +147,7 @@ class AddCommentServiceTest extends AbstractTestCase
         $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
         $review           = new CodeReview()->setId(1);
 
-        $this->lineReferenceFactory->expects($this->never())->method(static::anything());
+        $this->lineReferenceFactory->expects($this->once())->method('createFromReview')->willReturn(new LineReference());
         $this->repository->expects($this->once())->method('find')->willReturn($review);
         $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
         $this->commentRepository->expects($this->once())->method('save');
@@ -154,26 +156,7 @@ class AddCommentServiceTest extends AbstractTestCase
 
         $comment = $review->getComments()->first();
         static::assertInstanceOf(Comment::class, $comment);
-        static::assertSame(1704110400, $comment->getCreateTimestamp());
-        static::assertSame(1704110400, $comment->getUpdateTimestamp());
-    }
-
-    public function testAddCommentShouldWorkWithNullLogger(): void
-    {
-        $repositoryEntity = new Repository();
-        $revision         = new Revision()->setRepository($repositoryEntity)->setCommitHash('abc123');
-        $review           = new CodeReview();
-
-        $service = new AddCommentService(null, $this->repository, $this->commentRepository, $this->reviewRevisionService, $this->lineReferenceFactory);
-        $service->setClock(new MockClock('2024-01-01T12:00:00+00:00'));
-
-        $this->lineReferenceFactory->expects($this->never())->method(static::anything());
-        $this->repository->expects($this->once())->method('find')->willReturn($review);
-        $this->reviewRevisionService->expects($this->once())->method('getRevisions')->willReturn([$revision]);
-        $this->commentRepository->expects($this->once())->method('save');
-
-        $service->addComment(new User(), 1, 'file.php', 5, 'comment', null);
-
-        static::assertCount(1, $review->getComments());
+        static::assertSame(self::now()->getTimestamp(), $comment->getCreateTimestamp());
+        static::assertSame(self::now()->getTimestamp(), $comment->getUpdateTimestamp());
     }
 }

--- a/tests/Unit/Service/CodeReview/LineReferenceFactoryTest.php
+++ b/tests/Unit/Service/CodeReview/LineReferenceFactoryTest.php
@@ -14,14 +14,13 @@ use DR\Review\Service\CodeReview\LineReferenceFactory;
 use DR\Review\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
-use PHPUnit\Framework\MockObject\Stub;
 
 #[CoversClass(LineReferenceFactory::class)]
 class LineReferenceFactoryTest extends AbstractTestCase
 {
     private MockObject&CodeReviewDiffService $diffService;
     private MockObject&DiffFinder            $diffFinder;
-    private LineReferenceFactory       $factory;
+    private LineReferenceFactory             $factory;
 
     public function setUp(): void
     {
@@ -33,8 +32,8 @@ class LineReferenceFactoryTest extends AbstractTestCase
 
     public function testCreateFromReviewFallsBackWhenFileNotInDiff(): void
     {
-        $review      = new CodeReview();
-        $diffFiles   = [];
+        $review    = new CodeReview();
+        $diffFiles = [];
 
         $this->diffService->expects($this->once())->method('getDiff')->with($review)->willReturn($diffFiles);
         $this->diffFinder->expects($this->once())->method('findFileByPath')->with($diffFiles, 'src/Foo.php')->willReturn(null);
@@ -51,8 +50,8 @@ class LineReferenceFactoryTest extends AbstractTestCase
 
     public function testCreateFromReviewDelegatesWhenFileFound(): void
     {
-        $review      = new CodeReview();
-        $diffFile    = $this->createDiffFile('src/Foo.php', 'src/Foo.php', [
+        $review   = new CodeReview();
+        $diffFile = $this->createDiffFile('src/Foo.php', 'src/Foo.php', [
             $this->createLine(DiffLine::STATE_UNCHANGED, 5, 5),
             $this->createLine(DiffLine::STATE_UNCHANGED, 6, 6),
         ]);
@@ -169,11 +168,14 @@ class LineReferenceFactoryTest extends AbstractTestCase
         static::assertSame(LineReferenceStateEnum::Unknown, $ref->state);
     }
 
+    /**
+     * @param array<int, DiffLine> $lines
+     */
     private function createDiffFile(string $oldPath, string $newPath, array $lines): DiffFile
     {
-        $block              = new DiffBlock();
-        $block->lines       = $lines;
-        $file               = new DiffFile();
+        $block                = new DiffBlock();
+        $block->lines         = $lines;
+        $file                 = new DiffFile();
         $file->filePathBefore = $oldPath;
         $file->filePathAfter  = $newPath;
         $file->addBlock($block);
@@ -183,9 +185,9 @@ class LineReferenceFactoryTest extends AbstractTestCase
 
     private function createLine(int $state, ?int $lineNumberBefore, ?int $lineNumberAfter): DiffLine
     {
-        $line                    = new DiffLine($state, []);
-        $line->lineNumberBefore  = $lineNumberBefore;
-        $line->lineNumberAfter   = $lineNumberAfter;
+        $line                   = new DiffLine($state, []);
+        $line->lineNumberBefore = $lineNumberBefore;
+        $line->lineNumberAfter  = $lineNumberAfter;
 
         return $line;
     }

--- a/tests/Unit/Service/CodeReview/LineReferenceFactoryTest.php
+++ b/tests/Unit/Service/CodeReview/LineReferenceFactoryTest.php
@@ -1,0 +1,179 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\CodeReview;
+
+use DR\Review\Entity\Git\Diff\DiffBlock;
+use DR\Review\Entity\Git\Diff\DiffFile;
+use DR\Review\Entity\Git\Diff\DiffLine;
+use DR\Review\Entity\Review\CodeReview;
+use DR\Review\Entity\Review\LineReferenceStateEnum;
+use DR\Review\Service\CodeReview\CodeReviewDiffService;
+use DR\Review\Service\CodeReview\DiffFinder;
+use DR\Review\Service\CodeReview\LineReferenceFactory;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(LineReferenceFactory::class)]
+class LineReferenceFactoryTest extends AbstractTestCase
+{
+    private CodeReviewDiffService&MockObject $diffService;
+    private DiffFinder&MockObject            $diffFinder;
+    private LineReferenceFactory             $factory;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->diffService = $this->createMock(CodeReviewDiffService::class);
+        $this->diffFinder  = $this->createMock(DiffFinder::class);
+        $this->factory     = new LineReferenceFactory($this->diffService, $this->diffFinder);
+    }
+
+    public function testCreateFromReviewFallsBackWhenFileNotInDiff(): void
+    {
+        $review   = new CodeReview();
+        $diffFiles = [];
+
+        $this->diffService->expects($this->once())->method('getDiff')->with($review)->willReturn($diffFiles);
+        $this->diffFinder->expects($this->once())->method('findFileByPath')->with($diffFiles, 'src/Foo.php')->willReturn(null);
+
+        $ref = $this->factory->createFromReview($review, 'src/Foo.php', 10, 'abc123');
+
+        static::assertSame('src/Foo.php', $ref->oldPath);
+        static::assertSame('src/Foo.php', $ref->newPath);
+        static::assertSame(10, $ref->line);
+        static::assertSame(0, $ref->offset);
+        static::assertSame(10, $ref->lineAfter);
+        static::assertSame('abc123', $ref->headSha);
+    }
+
+    public function testCreateFromReviewDelegatesWhenFileFound(): void
+    {
+        $review   = new CodeReview();
+        $diffFile = $this->createDiffFile('src/Foo.php', 'src/Foo.php', [
+            $this->createLine(DiffLine::STATE_UNCHANGED, 5, 5),
+            $this->createLine(DiffLine::STATE_UNCHANGED, 6, 6),
+        ]);
+
+        $this->diffService->expects($this->once())->method('getDiff')->with($review)->willReturn([$diffFile]);
+        $this->diffFinder->expects($this->once())->method('findFileByPath')->willReturn($diffFile);
+
+        $ref = $this->factory->createFromReview($review, 'src/Foo.php', 6, 'abc123');
+
+        static::assertSame(6, $ref->line);
+        static::assertSame(0, $ref->offset);
+        static::assertSame(6, $ref->lineAfter);
+        static::assertSame(LineReferenceStateEnum::Unmodified, $ref->state);
+    }
+
+    public function testCreateFromDiffFileUnchangedLine(): void
+    {
+        $diffFile = $this->createDiffFile('old/Foo.php', 'new/Foo.php', [
+            $this->createLine(DiffLine::STATE_UNCHANGED, 3, 3),
+            $this->createLine(DiffLine::STATE_UNCHANGED, 4, 4),
+            $this->createLine(DiffLine::STATE_UNCHANGED, 5, 5),
+        ]);
+
+        $ref = $this->factory->createFromDiffFile($diffFile, 4, 'abc');
+
+        static::assertSame('old/Foo.php', $ref->oldPath);
+        static::assertSame('new/Foo.php', $ref->newPath);
+        static::assertSame(4, $ref->line);
+        static::assertSame(0, $ref->offset);
+        static::assertSame(4, $ref->lineAfter);
+        static::assertSame(LineReferenceStateEnum::Unmodified, $ref->state);
+    }
+
+    public function testCreateFromDiffFileAddedLine(): void
+    {
+        // Old: 1,2,3  New: 1,2,new_a(3),new_b(4),3→5
+        $diffFile = $this->createDiffFile('old/Foo.php', 'new/Foo.php', [
+            $this->createLine(DiffLine::STATE_UNCHANGED, 1, 1),
+            $this->createLine(DiffLine::STATE_UNCHANGED, 2, 2),
+            $this->createLine(DiffLine::STATE_ADDED, null, 3),
+            $this->createLine(DiffLine::STATE_ADDED, null, 4),
+            $this->createLine(DiffLine::STATE_UNCHANGED, 3, 5),
+        ]);
+
+        // Target: second added line (lineAfter=4); anchor is lineNumberBefore=2, offset=2
+        $ref = $this->factory->createFromDiffFile($diffFile, 4, 'sha1');
+
+        static::assertSame(2, $ref->line);
+        static::assertSame(2, $ref->offset);
+        static::assertSame(4, $ref->lineAfter);
+        static::assertSame(LineReferenceStateEnum::Added, $ref->state);
+        // invariant: line + offset = lineAfter
+        static::assertSame($ref->lineAfter, $ref->line + $ref->offset);
+    }
+
+    public function testCreateFromDiffFileModifiedLine(): void
+    {
+        $diffFile = $this->createDiffFile('old/Foo.php', 'new/Foo.php', [
+            $this->createLine(DiffLine::STATE_UNCHANGED, 9, 9),
+            $this->createLine(DiffLine::STATE_CHANGED, 10, 10),
+        ]);
+
+        $ref = $this->factory->createFromDiffFile($diffFile, 10, 'sha2');
+
+        static::assertSame(10, $ref->line);
+        static::assertSame(0, $ref->offset);
+        static::assertSame(10, $ref->lineAfter);
+        static::assertSame(LineReferenceStateEnum::Modified, $ref->state);
+    }
+
+    public function testCreateFromDiffFileUnchangedLineShiftedByPriorInsertions(): void
+    {
+        // Two lines added at the top shift old line 3 to new line 5
+        $diffFile = $this->createDiffFile('old/Foo.php', 'new/Foo.php', [
+            $this->createLine(DiffLine::STATE_UNCHANGED, 1, 1),
+            $this->createLine(DiffLine::STATE_ADDED, null, 2),
+            $this->createLine(DiffLine::STATE_ADDED, null, 3),
+            $this->createLine(DiffLine::STATE_UNCHANGED, 2, 4),
+            $this->createLine(DiffLine::STATE_UNCHANGED, 3, 5),
+        ]);
+
+        $ref = $this->factory->createFromDiffFile($diffFile, 5, 'sha3');
+
+        static::assertSame(3, $ref->line);
+        static::assertSame(0, $ref->offset);
+        static::assertSame(5, $ref->lineAfter);
+        static::assertSame(LineReferenceStateEnum::Unmodified, $ref->state);
+    }
+
+    public function testCreateFromDiffFileFallsBackWhenLineNotFound(): void
+    {
+        $diffFile = $this->createDiffFile('old/Foo.php', 'new/Foo.php', [
+            $this->createLine(DiffLine::STATE_UNCHANGED, 1, 1),
+        ]);
+
+        // Request line 99 which is not in the diff
+        $ref = $this->factory->createFromDiffFile($diffFile, 99, 'sha4');
+
+        static::assertSame(99, $ref->line);
+        static::assertSame(0, $ref->offset);
+        static::assertSame(99, $ref->lineAfter);
+        static::assertSame(LineReferenceStateEnum::Unknown, $ref->state);
+    }
+
+    private function createDiffFile(string $oldPath, string $newPath, array $lines): DiffFile
+    {
+        $block              = new DiffBlock();
+        $block->lines       = $lines;
+        $file               = new DiffFile();
+        $file->filePathBefore = $oldPath;
+        $file->filePathAfter  = $newPath;
+        $file->addBlock($block);
+
+        return $file;
+    }
+
+    private function createLine(int $state, ?int $lineNumberBefore, ?int $lineNumberAfter): DiffLine
+    {
+        $line                    = new DiffLine($state, []);
+        $line->lineNumberBefore  = $lineNumberBefore;
+        $line->lineNumberAfter   = $lineNumberAfter;
+
+        return $line;
+    }
+}

--- a/tests/Unit/Service/CodeReview/LineReferenceFactoryTest.php
+++ b/tests/Unit/Service/CodeReview/LineReferenceFactoryTest.php
@@ -14,13 +14,14 @@ use DR\Review\Service\CodeReview\LineReferenceFactory;
 use DR\Review\Tests\AbstractTestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 
 #[CoversClass(LineReferenceFactory::class)]
 class LineReferenceFactoryTest extends AbstractTestCase
 {
-    private CodeReviewDiffService&MockObject $diffService;
-    private DiffFinder&MockObject            $diffFinder;
-    private LineReferenceFactory             $factory;
+    private MockObject&CodeReviewDiffService $diffService;
+    private MockObject&DiffFinder            $diffFinder;
+    private LineReferenceFactory       $factory;
 
     public function setUp(): void
     {
@@ -32,8 +33,8 @@ class LineReferenceFactoryTest extends AbstractTestCase
 
     public function testCreateFromReviewFallsBackWhenFileNotInDiff(): void
     {
-        $review   = new CodeReview();
-        $diffFiles = [];
+        $review      = new CodeReview();
+        $diffFiles   = [];
 
         $this->diffService->expects($this->once())->method('getDiff')->with($review)->willReturn($diffFiles);
         $this->diffFinder->expects($this->once())->method('findFileByPath')->with($diffFiles, 'src/Foo.php')->willReturn(null);
@@ -50,8 +51,8 @@ class LineReferenceFactoryTest extends AbstractTestCase
 
     public function testCreateFromReviewDelegatesWhenFileFound(): void
     {
-        $review   = new CodeReview();
-        $diffFile = $this->createDiffFile('src/Foo.php', 'src/Foo.php', [
+        $review      = new CodeReview();
+        $diffFile    = $this->createDiffFile('src/Foo.php', 'src/Foo.php', [
             $this->createLine(DiffLine::STATE_UNCHANGED, 5, 5),
             $this->createLine(DiffLine::STATE_UNCHANGED, 6, 6),
         ]);
@@ -75,6 +76,8 @@ class LineReferenceFactoryTest extends AbstractTestCase
             $this->createLine(DiffLine::STATE_UNCHANGED, 5, 5),
         ]);
 
+        $this->diffService->expects($this->never())->method(static::anything());
+        $this->diffFinder->expects($this->never())->method(static::anything());
         $ref = $this->factory->createFromDiffFile($diffFile, 4, 'abc');
 
         static::assertSame('old/Foo.php', $ref->oldPath);
@@ -96,6 +99,9 @@ class LineReferenceFactoryTest extends AbstractTestCase
             $this->createLine(DiffLine::STATE_UNCHANGED, 3, 5),
         ]);
 
+        $this->diffService->expects($this->never())->method(static::anything());
+        $this->diffFinder->expects($this->never())->method(static::anything());
+
         // Target: second added line (lineAfter=4); anchor is lineNumberBefore=2, offset=2
         $ref = $this->factory->createFromDiffFile($diffFile, 4, 'sha1');
 
@@ -114,6 +120,8 @@ class LineReferenceFactoryTest extends AbstractTestCase
             $this->createLine(DiffLine::STATE_CHANGED, 10, 10),
         ]);
 
+        $this->diffService->expects($this->never())->method(static::anything());
+        $this->diffFinder->expects($this->never())->method(static::anything());
         $ref = $this->factory->createFromDiffFile($diffFile, 10, 'sha2');
 
         static::assertSame(10, $ref->line);
@@ -133,6 +141,8 @@ class LineReferenceFactoryTest extends AbstractTestCase
             $this->createLine(DiffLine::STATE_UNCHANGED, 3, 5),
         ]);
 
+        $this->diffService->expects($this->never())->method(static::anything());
+        $this->diffFinder->expects($this->never())->method(static::anything());
         $ref = $this->factory->createFromDiffFile($diffFile, 5, 'sha3');
 
         static::assertSame(3, $ref->line);
@@ -146,6 +156,9 @@ class LineReferenceFactoryTest extends AbstractTestCase
         $diffFile = $this->createDiffFile('old/Foo.php', 'new/Foo.php', [
             $this->createLine(DiffLine::STATE_UNCHANGED, 1, 1),
         ]);
+
+        $this->diffService->expects($this->never())->method(static::anything());
+        $this->diffFinder->expects($this->never())->method(static::anything());
 
         // Request line 99 which is not in the diff
         $ref = $this->factory->createFromDiffFile($diffFile, 99, 'sha4');

--- a/tests/Unit/Service/CodeReview/LineReferenceFactoryTest.php
+++ b/tests/Unit/Service/CodeReview/LineReferenceFactoryTest.php
@@ -30,7 +30,7 @@ class LineReferenceFactoryTest extends AbstractTestCase
         $this->factory     = new LineReferenceFactory($this->diffService, $this->diffFinder);
     }
 
-    public function testCreateFromReviewFallsBackWhenFileNotInDiff(): void
+    public function testCreateFromReviewFileNotInDiff(): void
     {
         $review    = new CodeReview();
         $diffFiles = [];
@@ -48,7 +48,7 @@ class LineReferenceFactoryTest extends AbstractTestCase
         static::assertSame('abc123', $ref->headSha);
     }
 
-    public function testCreateFromReviewDelegatesWhenFileFound(): void
+    public function testCreateFromReviewFileFound(): void
     {
         $review   = new CodeReview();
         $diffFile = $this->createDiffFile('src/Foo.php', 'src/Foo.php', [
@@ -129,7 +129,7 @@ class LineReferenceFactoryTest extends AbstractTestCase
         static::assertSame(LineReferenceStateEnum::Modified, $ref->state);
     }
 
-    public function testCreateFromDiffFileUnchangedLineShiftedByPriorInsertions(): void
+    public function testCreateFromDiffFileShiftedLine(): void
     {
         // Two lines added at the top shift old line 3 to new line 5
         $diffFile = $this->createDiffFile('old/Foo.php', 'new/Foo.php', [
@@ -150,7 +150,7 @@ class LineReferenceFactoryTest extends AbstractTestCase
         static::assertSame(LineReferenceStateEnum::Unmodified, $ref->state);
     }
 
-    public function testCreateFromDiffFileFallsBackWhenLineNotFound(): void
+    public function testCreateFromDiffFileLineNotFound(): void
     {
         $diffFile = $this->createDiffFile('old/Foo.php', 'new/Foo.php', [
             $this->createLine(DiffLine::STATE_UNCHANGED, 1, 1),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized how code review comments determine the exact referenced line using a dedicated line-reference factory, improving accuracy for added, modified, and unchanged lines.
  * Added consistent fallback behavior when the target file/line can’t be resolved from the diff.
* **Tests**
  * Updated and expanded unit tests for line-reference creation through both review- and diff-based paths, including offset/state handling and fallback cases.
  * Adjusted related assertions in comment service tests (including timestamp expectations).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->