### PR TITLE
Add reject_review MCP tool

### DIFF
--- a/src/Service/Ai/Mcp/RejectReviewTool.php
+++ b/src/Service/Ai/Mcp/RejectReviewTool.php
@@ -1,0 +1,45 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Service\Ai\Mcp;
+
+use DR\Review\Doctrine\Type\CodeReviewerStateType;
+use DR\Review\Entity\User\User;
+use DR\Review\Exception\Ai\CodeReviewNotFoundException;
+use DR\Review\Repository\Mcp\CodeReviewRepository;
+use DR\Review\Service\CodeReview\ChangeReviewerStateService;
+use DR\Utils\Assert;
+use Mcp\Capability\Attribute\McpTool;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+use Symfony\Bundle\SecurityBundle\Security;
+use Throwable;
+
+#[McpTool('reject_review', 'Reject a code review as the current user. The user is added as a reviewer if not already assigned.')]
+readonly class RejectReviewTool
+{
+    public function __construct(
+        private Security $security,
+        private CodeReviewRepository $reviewRepository,
+        private ChangeReviewerStateService $changeReviewerStateService
+    ) {
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function __invoke(#[Schema(description: 'The review id of the code review to reject', minimum: 1)] int $codeReviewId): string
+    {
+        $review = $this->reviewRepository->find($codeReviewId);
+        if ($review === null) {
+            throw new CodeReviewNotFoundException($codeReviewId);
+        }
+
+        $this->changeReviewerStateService->changeState(
+            $review,
+            Assert::isInstanceOf($this->security->getUser(), User::class),
+            CodeReviewerStateType::REJECTED
+        );
+
+        return sprintf('Review rejected. Reviewers state: %s', $review->getReviewersState());
+    }
+}

--- a/tests/Functional/Mcp/McpServerTest.php
+++ b/tests/Functional/Mcp/McpServerTest.php
@@ -106,7 +106,7 @@ class McpServerTest extends AbstractFunctionalTestCase
         static::assertIsArray($data['result']['tools']);
 
         $toolNames = array_column($data['result']['tools'], 'name');
-        static::assertCount(9, $toolNames);
+        static::assertCount(10, $toolNames);
         static::assertContains('get_code_review', $toolNames);
         static::assertContains('get_code_reviews', $toolNames);
         static::assertContains('get_code_review_diff', $toolNames);
@@ -116,6 +116,7 @@ class McpServerTest extends AbstractFunctionalTestCase
         static::assertContains('read_file', $toolNames);
         static::assertContains('list_files', $toolNames);
         static::assertContains('get_review_id_from_url', $toolNames);
+        static::assertContains('reject_review', $toolNames);
     }
 
     /**

--- a/tests/Unit/Service/Ai/Mcp/RejectReviewToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/RejectReviewToolTest.php
@@ -1,0 +1,65 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\Ai\Mcp;
+
+use DR\Review\Doctrine\Type\CodeReviewerStateType;
+use DR\Review\Entity\Review\CodeReview;
+use DR\Review\Entity\User\User;
+use DR\Review\Exception\Ai\CodeReviewNotFoundException;
+use DR\Review\Repository\Mcp\CodeReviewRepository;
+use DR\Review\Service\Ai\Mcp\RejectReviewTool;
+use DR\Review\Service\CodeReview\ChangeReviewerStateService;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Bundle\SecurityBundle\Security;
+use Throwable;
+
+#[CoversClass(RejectReviewTool::class)]
+class RejectReviewToolTest extends AbstractTestCase
+{
+    private Security&MockObject                  $security;
+    private CodeReviewRepository&MockObject      $reviewRepository;
+    private ChangeReviewerStateService&MockObject $changeReviewerStateService;
+    private RejectReviewTool                     $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->security                   = $this->createMock(Security::class);
+        $this->reviewRepository           = $this->createMock(CodeReviewRepository::class);
+        $this->changeReviewerStateService = $this->createMock(ChangeReviewerStateService::class);
+        $this->tool                       = new RejectReviewTool($this->security, $this->reviewRepository, $this->changeReviewerStateService);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testInvokeThrowsWhenReviewNotFound(): void
+    {
+        $this->security->expects($this->never())->method('getUser');
+        $this->reviewRepository->expects($this->once())->method('find')->with(123)->willReturn(null);
+        $this->changeReviewerStateService->expects($this->never())->method('changeState');
+
+        $this->expectException(CodeReviewNotFoundException::class);
+        ($this->tool)(123);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testInvokeShouldRejectReviewSuccessfully(): void
+    {
+        $user   = new User();
+        $review = new CodeReview();
+
+        $this->security->expects($this->once())->method('getUser')->willReturn($user);
+        $this->reviewRepository->expects($this->once())->method('find')->with(456)->willReturn($review);
+        $this->changeReviewerStateService->expects($this->once())->method('changeState')
+            ->with($review, $user, CodeReviewerStateType::REJECTED);
+
+        $result = ($this->tool)(456);
+        static::assertSame('Review rejected. Reviewers state: ' . $review->getReviewersState(), $result);
+    }
+}


### PR DESCRIPTION
## Why

AI clients using the 123view MCP server had no way to reject a code review. This adds a `reject_review` tool that mirrors the existing UI reject action, completing the reviewer workflow available over MCP.

## What changed

A single `#[McpTool('reject_review')]` class in `src/Service/Ai/Mcp/` following the same pattern as the existing `CodeReviewAddCommentTool`. It takes a `codeReviewId` (int) and delegates entirely to `ChangeReviewerStateService::changeState` with `CodeReviewerStateType::REJECTED`.

Key design points:
- The current user is added as a reviewer if not already assigned (handled by `changeState`, same as the UI).
- All events are dispatched automatically via `changeState`: `ReviewerAdded`, `ReviewerStateChanged`, `ReviewRejected`, and `ReviewStateChanged`.
- Throws `CodeReviewNotFoundException` if the review id is invalid (surfaces as an MCP error to the client).
- Returns a confirmation string including the resulting reviewers state, e.g. `Review rejected. Reviewers state: rejected`.
- URLs should be resolved first with the existing `get_review_id_from_url` tool before calling this one.
- Auto-discovered via the existing `mcp.php` `scan_dirs` config -- no registration needed.

## Tests

Unit test covering the happy path and the not-found error case.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AI MCP tool to reject a code review for the currently authenticated user.
  * The tool confirms the action and reports the updated reviewer state.
* **Bug Fixes**
  * When the specified review ID doesn’t exist, the system returns a clear not-found error instead of failing silently.
* **Tests**
  * Updated the MCP server tool list expectations and added unit coverage for success and not-found scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->