### PR TITLE
Add resolve comment mcp tool

### DIFF
--- a/src/Exception/Ai/CommentNotFoundException.php
+++ b/src/Exception/Ai/CommentNotFoundException.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Exception\Ai;
+
+use RuntimeException;
+use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionExceptionInterface;
+
+class CommentNotFoundException extends RuntimeException implements ToolExecutionExceptionInterface
+{
+    public function __construct(private readonly int $commentId)
+    {
+        parent::__construct('Comment not found: ' . $this->commentId);
+    }
+
+    public function getToolCallResult(): string
+    {
+        return sprintf('Comment %d not found.', $this->commentId);
+    }
+}

--- a/src/Exception/Ai/CommentNotInReviewException.php
+++ b/src/Exception/Ai/CommentNotInReviewException.php
@@ -1,0 +1,20 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Exception\Ai;
+
+use RuntimeException;
+use Symfony\AI\Agent\Toolbox\Exception\ToolExecutionExceptionInterface;
+
+class CommentNotInReviewException extends RuntimeException implements ToolExecutionExceptionInterface
+{
+    public function __construct(private readonly int $commentId, private readonly int $reviewId)
+    {
+        parent::__construct(sprintf('Comment %d does not belong to review %d.', $this->commentId, $this->reviewId));
+    }
+
+    public function getToolCallResult(): string
+    {
+        return sprintf('Comment %d does not belong to review %d.', $this->commentId, $this->reviewId);
+    }
+}

--- a/src/Service/Ai/Mcp/ResolveCommentTool.php
+++ b/src/Service/Ai/Mcp/ResolveCommentTool.php
@@ -1,0 +1,38 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Service\Ai\Mcp;
+
+use DR\Review\Exception\Ai\CodeReviewNotFoundException;
+use DR\Review\Exception\Ai\CommentNotFoundException;
+use DR\Review\Exception\Ai\CommentNotInReviewException;
+use DR\Review\Repository\Mcp\CodeReviewRepository;
+use DR\Review\Service\CodeReview\Comment\ResolveCommentService;
+use Mcp\Capability\Attribute\McpTool;
+use Symfony\AI\Platform\Contract\JsonSchema\Attribute\Schema;
+use Throwable;
+
+#[McpTool('resolve_comment', 'Resolve a comment in a code review. The reviewId must match the review the comment belongs to.')]
+readonly class ResolveCommentTool
+{
+    public function __construct(
+        private CodeReviewRepository $reviewRepository,
+        private ResolveCommentService $resolveCommentService
+    ) {
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function __invoke(
+        #[Schema(description: 'The id of the code review the comment belongs to', minimum: 1)] int $codeReviewId,
+        #[Schema(description: 'The id of the comment to resolve', minimum: 1)] int $commentId
+    ): string {
+        $review = $this->reviewRepository->find($codeReviewId);
+        if ($review === null) {
+            throw new CodeReviewNotFoundException($codeReviewId);
+        }
+
+        return $this->resolveCommentService->resolve($commentId, $codeReviewId);
+    }
+}

--- a/src/Service/Ai/Mcp/ResolveCommentTool.php
+++ b/src/Service/Ai/Mcp/ResolveCommentTool.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 namespace DR\Review\Service\Ai\Mcp;
 
 use DR\Review\Exception\Ai\CodeReviewNotFoundException;
-use DR\Review\Exception\Ai\CommentNotFoundException;
-use DR\Review\Exception\Ai\CommentNotInReviewException;
 use DR\Review\Repository\Mcp\CodeReviewRepository;
 use DR\Review\Service\CodeReview\Comment\ResolveCommentService;
 use Mcp\Capability\Attribute\McpTool;
@@ -15,10 +13,8 @@ use Throwable;
 #[McpTool('resolve_comment', 'Resolve a comment in a code review. The reviewId must match the review the comment belongs to.')]
 readonly class ResolveCommentTool
 {
-    public function __construct(
-        private CodeReviewRepository $reviewRepository,
-        private ResolveCommentService $resolveCommentService
-    ) {
+    public function __construct(private CodeReviewRepository $reviewRepository, private ResolveCommentService $resolveCommentService)
+    {
     }
 
     /**

--- a/src/Service/CodeReview/Comment/ResolveCommentService.php
+++ b/src/Service/CodeReview/Comment/ResolveCommentService.php
@@ -1,0 +1,41 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Service\CodeReview\Comment;
+
+use DR\Review\Doctrine\Type\CommentStateType;
+use DR\Review\Exception\Ai\CommentNotFoundException;
+use DR\Review\Exception\Ai\CommentNotInReviewException;
+use DR\Review\Repository\Review\CommentRepository;
+
+class ResolveCommentService
+{
+    public function __construct(private readonly CommentRepository $commentRepository)
+    {
+    }
+
+    /**
+     * @throws CommentNotFoundException
+     * @throws CommentNotInReviewException
+     */
+    public function resolve(int $commentId, int $reviewId): string
+    {
+        $comment = $this->commentRepository->find($commentId);
+        if ($comment === null) {
+            throw new CommentNotFoundException($commentId);
+        }
+
+        if ($comment->getReview()->getId() !== $reviewId) {
+            throw new CommentNotInReviewException($commentId, $reviewId);
+        }
+
+        if ($comment->getState() === CommentStateType::RESOLVED) {
+            return sprintf('Comment %d is already resolved.', $commentId);
+        }
+
+        $comment->setState(CommentStateType::RESOLVED);
+        $this->commentRepository->save($comment, true);
+
+        return sprintf('Comment %d resolved.', $commentId);
+    }
+}

--- a/tests/Functional/Mcp/McpServerTest.php
+++ b/tests/Functional/Mcp/McpServerTest.php
@@ -106,7 +106,7 @@ class McpServerTest extends AbstractFunctionalTestCase
         static::assertIsArray($data['result']['tools']);
 
         $toolNames = array_column($data['result']['tools'], 'name');
-        static::assertCount(10, $toolNames);
+        static::assertCount(11, $toolNames);
         static::assertContains('get_code_review', $toolNames);
         static::assertContains('get_code_reviews', $toolNames);
         static::assertContains('get_code_review_diff', $toolNames);
@@ -117,6 +117,7 @@ class McpServerTest extends AbstractFunctionalTestCase
         static::assertContains('list_files', $toolNames);
         static::assertContains('get_review_id_from_url', $toolNames);
         static::assertContains('reject_review', $toolNames);
+        static::assertContains('resolve_comment', $toolNames);
     }
 
     /**

--- a/tests/Unit/Exception/Ai/CommentNotFoundExceptionTest.php
+++ b/tests/Unit/Exception/Ai/CommentNotFoundExceptionTest.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Exception\Ai;
+
+use DR\Review\Exception\Ai\CommentNotFoundException;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(CommentNotFoundException::class)]
+class CommentNotFoundExceptionTest extends AbstractTestCase
+{
+    public function testGetToolCallResult(): void
+    {
+        $exception = new CommentNotFoundException(456);
+
+        static::assertSame('Comment 456 not found.', $exception->getToolCallResult());
+    }
+}

--- a/tests/Unit/Exception/Ai/CommentNotInReviewExceptionTest.php
+++ b/tests/Unit/Exception/Ai/CommentNotInReviewExceptionTest.php
@@ -1,0 +1,19 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Exception\Ai;
+
+use DR\Review\Exception\Ai\CommentNotInReviewException;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+
+#[CoversClass(CommentNotInReviewException::class)]
+class CommentNotInReviewExceptionTest extends AbstractTestCase
+{
+    public function testGetToolCallResult(): void
+    {
+        $exception = new CommentNotInReviewException(456, 123);
+
+        static::assertSame('Comment 456 does not belong to review 123.', $exception->getToolCallResult());
+    }
+}

--- a/tests/Unit/Service/Ai/Mcp/ResolveCommentToolTest.php
+++ b/tests/Unit/Service/Ai/Mcp/ResolveCommentToolTest.php
@@ -1,0 +1,56 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\Ai\Mcp;
+
+use DR\Review\Entity\Review\CodeReview;
+use DR\Review\Exception\Ai\CodeReviewNotFoundException;
+use DR\Review\Repository\Mcp\CodeReviewRepository;
+use DR\Review\Service\Ai\Mcp\ResolveCommentTool;
+use DR\Review\Service\CodeReview\Comment\ResolveCommentService;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use Throwable;
+
+#[CoversClass(ResolveCommentTool::class)]
+class ResolveCommentToolTest extends AbstractTestCase
+{
+    private CodeReviewRepository&MockObject  $reviewRepository;
+    private ResolveCommentService&MockObject $resolveCommentService;
+    private ResolveCommentTool               $tool;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->reviewRepository      = $this->createMock(CodeReviewRepository::class);
+        $this->resolveCommentService = $this->createMock(ResolveCommentService::class);
+        $this->tool                  = new ResolveCommentTool($this->reviewRepository, $this->resolveCommentService);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testInvokeThrowsWhenReviewNotFound(): void
+    {
+        $this->reviewRepository->expects($this->once())->method('find')->with(123)->willReturn(null);
+        $this->resolveCommentService->expects($this->never())->method('resolve');
+
+        $this->expectException(CodeReviewNotFoundException::class);
+        ($this->tool)(123, 456);
+    }
+
+    /**
+     * @throws Throwable
+     */
+    public function testInvokeShouldResolveComment(): void
+    {
+        $review = new CodeReview();
+
+        $this->reviewRepository->expects($this->once())->method('find')->with(123)->willReturn($review);
+        $this->resolveCommentService->expects($this->once())->method('resolve')->with(456, 123)->willReturn('Comment 456 resolved.');
+
+        $result = ($this->tool)(123, 456);
+        static::assertSame('Comment 456 resolved.', $result);
+    }
+}

--- a/tests/Unit/Service/CodeReview/Comment/ResolveCommentServiceTest.php
+++ b/tests/Unit/Service/CodeReview/Comment/ResolveCommentServiceTest.php
@@ -48,7 +48,7 @@ class ResolveCommentServiceTest extends AbstractTestCase
         $this->service->resolve(456, 123);
     }
 
-    public function testResolveReturnsAlreadyResolvedWhenStateIsResolved(): void
+    public function testResolveAlreadyResolved(): void
     {
         $review  = new CodeReview()->setId(123);
         $comment = new Comment()->setId(456)->setReview($review)->setState(CommentStateType::RESOLVED);

--- a/tests/Unit/Service/CodeReview/Comment/ResolveCommentServiceTest.php
+++ b/tests/Unit/Service/CodeReview/Comment/ResolveCommentServiceTest.php
@@ -1,0 +1,75 @@
+<?php
+declare(strict_types=1);
+
+namespace DR\Review\Tests\Unit\Service\CodeReview\Comment;
+
+use DR\Review\Doctrine\Type\CommentStateType;
+use DR\Review\Entity\Review\CodeReview;
+use DR\Review\Entity\Review\Comment;
+use DR\Review\Exception\Ai\CommentNotFoundException;
+use DR\Review\Exception\Ai\CommentNotInReviewException;
+use DR\Review\Repository\Review\CommentRepository;
+use DR\Review\Service\CodeReview\Comment\ResolveCommentService;
+use DR\Review\Tests\AbstractTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[CoversClass(ResolveCommentService::class)]
+class ResolveCommentServiceTest extends AbstractTestCase
+{
+    private CommentRepository&MockObject $commentRepository;
+    private ResolveCommentService        $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->commentRepository = $this->createMock(CommentRepository::class);
+        $this->service           = new ResolveCommentService($this->commentRepository);
+    }
+
+    public function testResolveThrowsWhenCommentNotFound(): void
+    {
+        $this->commentRepository->expects($this->once())->method('find')->with(456)->willReturn(null);
+        $this->commentRepository->expects($this->never())->method('save');
+
+        $this->expectException(CommentNotFoundException::class);
+        $this->service->resolve(456, 123);
+    }
+
+    public function testResolveThrowsWhenCommentNotInReview(): void
+    {
+        $review  = new CodeReview()->setId(999);
+        $comment = new Comment()->setId(456)->setReview($review);
+
+        $this->commentRepository->expects($this->once())->method('find')->with(456)->willReturn($comment);
+        $this->commentRepository->expects($this->never())->method('save');
+
+        $this->expectException(CommentNotInReviewException::class);
+        $this->service->resolve(456, 123);
+    }
+
+    public function testResolveReturnsAlreadyResolvedWhenStateIsResolved(): void
+    {
+        $review  = new CodeReview()->setId(123);
+        $comment = new Comment()->setId(456)->setReview($review)->setState(CommentStateType::RESOLVED);
+
+        $this->commentRepository->expects($this->once())->method('find')->with(456)->willReturn($comment);
+        $this->commentRepository->expects($this->never())->method('save');
+
+        $result = $this->service->resolve(456, 123);
+        static::assertSame('Comment 456 is already resolved.', $result);
+    }
+
+    public function testResolveSetsStateAndFlushes(): void
+    {
+        $review  = new CodeReview()->setId(123);
+        $comment = new Comment()->setId(456)->setReview($review)->setState(CommentStateType::OPEN);
+
+        $this->commentRepository->expects($this->once())->method('find')->with(456)->willReturn($comment);
+        $this->commentRepository->expects($this->once())->method('save')->with($comment, true);
+
+        $result = $this->service->resolve(456, 123);
+        static::assertSame('Comment 456 resolved.', $result);
+        static::assertSame(CommentStateType::RESOLVED, $comment->getState());
+    }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for resolving comments through the app’s AI/MCP tooling.
  * Comments can now be marked as resolved, with clear feedback when a comment is already resolved or cannot be resolved.
  * Added user-facing messages for missing comments and comments that do not belong to the selected review.

* **Tests**
  * Added coverage for comment resolution flow and related error cases.
  * Updated tool सूची expectations to include the new comment resolution capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->